### PR TITLE
Implement auth forms and Firebase hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@capacitor/status-bar": "7.0.1",
     "@ionic/angular": "^8.0.0",
     "ionicons": "^7.0.0",
+    "firebase": "^10.7.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -11,6 +11,20 @@ export const routes: Routes = [
       import('./check-in/check-in.page').then((m) => m.CheckInPage),
   },
   {
+    path: 'login',
+    loadComponent: () => import('./login/login.page').then((m) => m.LoginPage),
+  },
+  {
+    path: 'register',
+    loadComponent: () =>
+      import('./register/register.page').then((m) => m.RegisterPage),
+  },
+  {
+    path: 'child-account',
+    loadComponent: () =>
+      import('./child-account/child-account.page').then((m) => m.ChildAccountPage),
+  },
+  {
     path: '',
     redirectTo: 'home',
     pathMatch: 'full',

--- a/src/app/check-in/check-in.page.html
+++ b/src/app/check-in/check-in.page.html
@@ -32,7 +32,23 @@
     </ion-item>
     <ion-item>
       <ion-label position="stacked">Mood</ion-label>
-      <ion-input [(ngModel)]="form.mood" placeholder="😊"></ion-input>
+      <ion-segment [(ngModel)]="form.mood">
+        <ion-segment-button value="😀">
+          <ion-label>😀</ion-label>
+        </ion-segment-button>
+        <ion-segment-button value="🙂">
+          <ion-label>🙂</ion-label>
+        </ion-segment-button>
+        <ion-segment-button value="😐">
+          <ion-label>😐</ion-label>
+        </ion-segment-button>
+        <ion-segment-button value="☹️">
+          <ion-label>☹️</ion-label>
+        </ion-segment-button>
+        <ion-segment-button value="😭">
+          <ion-label>😭</ion-label>
+        </ion-segment-button>
+      </ion-segment>
     </ion-item>
     <ion-item>
       <ion-label position="stacked">Sleep Quality</ion-label>

--- a/src/app/check-in/check-in.page.ts
+++ b/src/app/check-in/check-in.page.ts
@@ -1,12 +1,28 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonTextarea } from '@ionic/angular/standalone';
+import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonTextarea, IonSegment, IonSegmentButton } from '@ionic/angular/standalone';
+import { FirebaseService } from '../services/firebase.service';
 
 @Component({
   selector: 'app-check-in',
   standalone: true,
-  imports: [CommonModule, FormsModule, IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonTextarea],
+  imports: [
+    CommonModule,
+    FormsModule,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
+    IonContent,
+    IonInput,
+    IonItem,
+    IonLabel,
+    IonButton,
+    IonList,
+    IonTextarea,
+    IonSegment,
+    IonSegmentButton,
+  ],
   templateUrl: './check-in.page.html',
   styleUrls: ['./check-in.page.scss'],
 })
@@ -25,8 +41,15 @@ export class CheckInPage {
     needsHelp: false,
   };
 
-  submit() {
-    console.log('Check-in data:', this.form);
-    // TODO: integrate with Firebase service
+  constructor(private fbService: FirebaseService) {}
+
+  async submit() {
+    const user = this.fbService.auth.currentUser;
+    await this.fbService.saveDailyCheckin({
+      ...this.form,
+      userId: user ? user.uid : null,
+      date: new Date().toISOString(),
+    });
+    console.log('Check-in saved');
   }
 }

--- a/src/app/child-account/child-account.page.html
+++ b/src/app/child-account/child-account.page.html
@@ -1,0 +1,19 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Create Child Account</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content class="ion-padding">
+  <ion-list>
+    <ion-item>
+      <ion-label position="stacked">Child Email</ion-label>
+      <ion-input type="email" [(ngModel)]="form.email"></ion-input>
+    </ion-item>
+    <ion-item>
+      <ion-label position="stacked">Password</ion-label>
+      <ion-input type="password" [(ngModel)]="form.password"></ion-input>
+    </ion-item>
+  </ion-list>
+  <ion-button expand="block" (click)="create()">Create</ion-button>
+</ion-content>

--- a/src/app/child-account/child-account.page.ts
+++ b/src/app/child-account/child-account.page.ts
@@ -1,0 +1,28 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList } from '@ionic/angular/standalone';
+import { FirebaseService } from '../services/firebase.service';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-child-account',
+  standalone: true,
+  imports: [CommonModule, FormsModule, IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList],
+  templateUrl: './child-account.page.html',
+  styleUrls: ['./child-account.page.scss'],
+})
+export class ChildAccountPage {
+  form = { email: '', password: '' };
+
+  constructor(private fb: FirebaseService, private router: Router) {}
+
+  async create() {
+    const user = this.fb.auth.currentUser;
+    if (!user) {
+      return;
+    }
+    await this.fb.createChildAccount(this.form.email, this.form.password, user.uid);
+    this.router.navigateByUrl('/home');
+  }
+}

--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -15,5 +15,8 @@
 
   <div class="ion-padding">
     <ion-button routerLink="/check-in" expand="block">Daily Check-In</ion-button>
+    <ion-button routerLink="/login" expand="block">Login</ion-button>
+    <ion-button routerLink="/register" expand="block">Register</ion-button>
+    <ion-button routerLink="/child-account" expand="block">Create Child</ion-button>
   </div>
 </ion-content>

--- a/src/app/login/login.page.html
+++ b/src/app/login/login.page.html
@@ -1,0 +1,19 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Login</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content class="ion-padding">
+  <ion-list>
+    <ion-item>
+      <ion-label position="stacked">Email</ion-label>
+      <ion-input type="email" [(ngModel)]="form.email"></ion-input>
+    </ion-item>
+    <ion-item>
+      <ion-label position="stacked">Password</ion-label>
+      <ion-input type="password" [(ngModel)]="form.password"></ion-input>
+    </ion-item>
+  </ion-list>
+  <ion-button expand="block" (click)="login()">Login</ion-button>
+</ion-content>

--- a/src/app/login/login.page.ts
+++ b/src/app/login/login.page.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList } from '@ionic/angular/standalone';
+import { FirebaseService } from '../services/firebase.service';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-login',
+  standalone: true,
+  imports: [CommonModule, FormsModule, IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList],
+  templateUrl: './login.page.html',
+  styleUrls: ['./login.page.scss'],
+})
+export class LoginPage {
+  form = { email: '', password: '' };
+
+  constructor(private fb: FirebaseService, private router: Router) {}
+
+  async login() {
+    await this.fb.login(this.form.email, this.form.password);
+    this.router.navigateByUrl('/home');
+  }
+}

--- a/src/app/register/register.page.html
+++ b/src/app/register/register.page.html
@@ -1,0 +1,19 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Register</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content class="ion-padding">
+  <ion-list>
+    <ion-item>
+      <ion-label position="stacked">Email</ion-label>
+      <ion-input type="email" [(ngModel)]="form.email"></ion-input>
+    </ion-item>
+    <ion-item>
+      <ion-label position="stacked">Password</ion-label>
+      <ion-input type="password" [(ngModel)]="form.password"></ion-input>
+    </ion-item>
+  </ion-list>
+  <ion-button expand="block" (click)="register()">Register</ion-button>
+</ion-content>

--- a/src/app/register/register.page.ts
+++ b/src/app/register/register.page.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList } from '@ionic/angular/standalone';
+import { FirebaseService } from '../services/firebase.service';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-register',
+  standalone: true,
+  imports: [CommonModule, FormsModule, IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList],
+  templateUrl: './register.page.html',
+  styleUrls: ['./register.page.scss'],
+})
+export class RegisterPage {
+  form = { email: '', password: '' };
+
+  constructor(private fb: FirebaseService, private router: Router) {}
+
+  async register() {
+    await this.fb.register(this.form.email, this.form.password);
+    this.router.navigateByUrl('/login');
+  }
+}

--- a/src/app/services/firebase.service.ts
+++ b/src/app/services/firebase.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { initializeApp } from 'firebase/app';
+import { getAuth, createUserWithEmailAndPassword, signInWithEmailAndPassword, Auth, UserCredential } from 'firebase/auth';
+import { getFirestore, collection, addDoc } from 'firebase/firestore';
+import { environment } from '../../environments/environment';
+
+@Injectable({ providedIn: 'root' })
+export class FirebaseService {
+  private app = initializeApp(environment.firebase);
+  auth: Auth = getAuth(this.app);
+  db = getFirestore(this.app);
+
+  register(email: string, password: string): Promise<UserCredential> {
+    return createUserWithEmailAndPassword(this.auth, email, password);
+  }
+
+  login(email: string, password: string): Promise<UserCredential> {
+    return signInWithEmailAndPassword(this.auth, email, password);
+  }
+
+  async createChildAccount(email: string, password: string, parentId: string) {
+    const cred = await createUserWithEmailAndPassword(this.auth, email, password);
+    await addDoc(collection(this.db, 'parentChildLinks'), { parentId, childId: cred.user.uid });
+    return cred;
+  }
+
+  saveDailyCheckin(data: any) {
+    return addDoc(collection(this.db, 'dailyCheckins'), data);
+  }
+}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,8 @@
 export const environment = {
-  production: true
+  production: true,
+  firebase: {
+    apiKey: 'YOUR_API_KEY',
+    authDomain: 'YOUR_AUTH_DOMAIN',
+    projectId: 'YOUR_PROJECT_ID',
+  },
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,7 +3,12 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  firebase: {
+    apiKey: 'YOUR_API_KEY',
+    authDomain: 'YOUR_AUTH_DOMAIN',
+    projectId: 'YOUR_PROJECT_ID',
+  },
 };
 
 /*

--- a/todo.md
+++ b/todo.md
@@ -2,23 +2,23 @@
 
 ## 🔐 Authentication
 - [x] Set up Firebase Authentication
-- [ ] Implement parent registration & login
-- [ ] Enable child account creation under parent
+- [x] Implement parent registration & login
+- [x] Enable child account creation under parent
 - [ ] Role-based access control in Firebase rules
 
 ## 👨‍👩‍👧 Onboarding
-- [ ] Parent creates or links child profile
+- [x] Parent creates or links child profile
 - [ ] Child logs in via invite or code
-- [ ] Store parent-child linkage in Firestore
+- [x] Store parent-child linkage in Firestore
 
 ## 📆 Daily Check-In (Child)
-- [ ] Gratitude prompt (3 inputs)
-- [ ] One wish entry
-- [ ] Weekly goal setting
-- [ ] Next birthday selector
-- [ ] Mood tracker with emojis
-- [ ] Sleep, appetite, mood descriptions
-- [ ] Form save to `/dailyCheckins`
+- [x] Gratitude prompt (3 inputs)
+- [x] One wish entry
+- [x] Weekly goal setting
+- [x] Next birthday selector
+- [x] Mood tracker with emojis
+- [x] Sleep, appetite, mood descriptions
+- [x] Form save to `/dailyCheckins`
 
 ## 🧠 Mental & Emotional Status
 - [ ] School and home treatment checkboxes


### PR DESCRIPTION
## Summary
- add Firebase env placeholders
- create Firebase service for auth and Firestore writes
- implement login, register and child account pages
- hook check-in form to Firebase and add emoji mood tracker
- update home page links and TODO checklist

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a252651d48327a4c157ec27561685