### PR TITLE
Add Firestore rules and docs

### DIFF
--- a/docs/firebase-setup.md
+++ b/docs/firebase-setup.md
@@ -1,0 +1,31 @@
+# Firebase Setup
+
+This document describes the Firestore collections and provides basic security rules and index configuration.
+
+## Collections
+
+- **parentChildLinks** – links a `parentId` to a `childId`.
+- **dailyCheckins** – stored check‑in data from the child. Each document should include `childId`, `parentId` and a `timestamp` field.
+- **mentalStatus** – mental health form results. Store `childId`, `parentId` and `timestamp`.
+- **bibleQuizzes** – quiz attempts. Store `childId`, `parentId`, `score` and `timestamp`.
+- **essays** – essay tracker items. Store `childId`, `parentId` and `timestamp`.
+- **schoolWork** – academic progress entries. Store `childId`, `parentId` and `timestamp`.
+- **projects** – project tracker entries. Store `childId`, `parentId` and `timestamp`.
+- **bibleQuestions** – pool of quiz questions. No user‑specific fields required.
+
+Every document that references a child should include `childId` and `parentId`. This allows security rules to verify ownership.
+
+## Security Rules
+
+A set of sample Firestore rules is provided in `firebase/firestore.rules`. These rules grant each parent read access to their child’s documents while allowing the child to create and read their own data.
+
+## Indexes
+
+When querying data by `childId` and ordering by `timestamp`, Firestore requires composite indexes. Example index configuration is included in `firebase/firestore.indexes.json`.
+
+Copy these files into your Firebase project and deploy them using the Firebase CLI:
+
+```bash
+firebase deploy --only firestore:rules
+firebase deploy --only firestore:indexes
+```

--- a/firebase/firestore.indexes.json
+++ b/firebase/firestore.indexes.json
@@ -1,0 +1,29 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "dailyCheckins",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "childId", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "mentalStatus",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "childId", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "bibleQuizzes",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "childId", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "DESCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -1,0 +1,59 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    function isParent(doc) {
+      return request.auth != null && request.auth.uid == doc.data.parentId;
+    }
+
+    function isChild(doc) {
+      return request.auth != null && request.auth.uid == doc.data.childId;
+    }
+
+    match /parentChildLinks/{linkId} {
+      allow read: if request.auth != null && (isParent(resource) || isChild(resource));
+      allow write: if request.auth != null && request.auth.uid == request.resource.data.parentId;
+    }
+
+    match /dailyCheckins/{docId} {
+      allow read: if isParent(resource) || isChild(resource);
+      allow create: if isChild(request.resource);
+      allow update, delete: if false;
+    }
+
+    match /mentalStatus/{docId} {
+      allow read: if isParent(resource) || isChild(resource);
+      allow create: if isChild(request.resource);
+      allow update, delete: if false;
+    }
+
+    match /bibleQuizzes/{docId} {
+      allow read: if isParent(resource) || isChild(resource);
+      allow create: if isChild(request.resource);
+      allow update, delete: if false;
+    }
+
+    match /essays/{docId} {
+      allow read: if isParent(resource) || isChild(resource);
+      allow create: if isChild(request.resource);
+      allow update, delete: if false;
+    }
+
+    match /schoolWork/{docId} {
+      allow read: if isParent(resource) || isChild(resource);
+      allow create: if isChild(request.resource);
+      allow update, delete: if false;
+    }
+
+    match /projects/{docId} {
+      allow read: if isParent(resource) || isChild(resource);
+      allow create: if isChild(request.resource);
+      allow update, delete: if false;
+    }
+
+    match /bibleQuestions/{docId} {
+      allow read: if request.auth != null;
+      allow write: if false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- document Firestore collections, rules and indexes
- add sample Firestore security rules
- provide example index configuration

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a2933ba14832793d04d435cedbc71