### PR TITLE
Implement basic notification and leaderboard

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -50,6 +50,11 @@ export const routes: Routes = [
       import('./project-tracker/project-tracker.page').then((m) => m.ProjectTrackerPage),
   },
   {
+    path: 'leaderboard',
+    loadComponent: () =>
+      import('./leaderboard/leaderboard.page').then((m) => m.LeaderboardPage),
+  },
+  {
     path: '',
     redirectTo: 'home',
     pathMatch: 'full',

--- a/src/app/check-in/check-in.page.ts
+++ b/src/app/check-in/check-in.page.ts
@@ -45,9 +45,11 @@ export class CheckInPage {
 
   async submit() {
     const user = this.fbService.auth.currentUser;
+    const parentId = user ? await this.fbService.getParentIdForChild(user.uid) : null;
     await this.fbService.saveDailyCheckin({
       ...this.form,
       userId: user ? user.uid : null,
+      parentId,
       date: new Date().toISOString(),
     });
     console.log('Check-in saved');

--- a/src/app/child-account/child-account.page.html
+++ b/src/app/child-account/child-account.page.html
@@ -14,6 +14,10 @@
       <ion-label position="stacked">Password</ion-label>
       <ion-input type="password" [(ngModel)]="form.password"></ion-input>
     </ion-item>
+    <ion-item>
+      <ion-label position="stacked">Age</ion-label>
+      <ion-input type="number" [(ngModel)]="form.age"></ion-input>
+    </ion-item>
   </ion-list>
   <ion-button expand="block" (click)="create()">Create</ion-button>
 </ion-content>

--- a/src/app/child-account/child-account.page.ts
+++ b/src/app/child-account/child-account.page.ts
@@ -13,7 +13,7 @@ import { Router } from '@angular/router';
   styleUrls: ['./child-account.page.scss'],
 })
 export class ChildAccountPage {
-  form = { email: '', password: '' };
+  form = { email: '', password: '', age: null as number | null };
 
   constructor(private fb: FirebaseService, private router: Router) {}
 
@@ -22,7 +22,15 @@ export class ChildAccountPage {
     if (!user) {
       return;
     }
-    await this.fb.createChildAccount(this.form.email, this.form.password, user.uid);
+    if (this.form.age === null) {
+      return;
+    }
+    await this.fb.createChildAccount(
+      this.form.email,
+      this.form.password,
+      user.uid,
+      this.form.age
+    );
     this.router.navigateByUrl('/home');
   }
 }

--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -23,5 +23,6 @@
     <ion-button routerLink="/essay-tracker" expand="block">Essay Tracker</ion-button>
     <ion-button routerLink="/academic-progress" expand="block">Academic Progress</ion-button>
     <ion-button routerLink="/project-tracker" expand="block">Project Tracker</ion-button>
+    <ion-button routerLink="/leaderboard" expand="block">Leaderboard</ion-button>
   </div>
 </ion-content>

--- a/src/app/leaderboard/leaderboard.page.html
+++ b/src/app/leaderboard/leaderboard.page.html
@@ -1,0 +1,13 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Leaderboard</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+  <ion-list>
+    <ion-item *ngFor="let item of leaders; let i = index">
+      <ion-label>{{ i + 1 }}. {{ item.id }} - {{ item.points }} pts (Streak: {{ item.streak || 0 }})</ion-label>
+    </ion-item>
+  </ion-list>
+</ion-content>

--- a/src/app/leaderboard/leaderboard.page.ts
+++ b/src/app/leaderboard/leaderboard.page.ts
@@ -1,0 +1,38 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonContent,
+  IonList,
+  IonItem,
+  IonLabel,
+} from '@ionic/angular/standalone';
+import { FirebaseService } from '../services/firebase.service';
+
+@Component({
+  selector: 'app-leaderboard',
+  standalone: true,
+  imports: [
+    CommonModule,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
+    IonContent,
+    IonList,
+    IonItem,
+    IonLabel,
+  ],
+  templateUrl: './leaderboard.page.html',
+  styleUrls: ['./leaderboard.page.scss'],
+})
+export class LeaderboardPage implements OnInit {
+  leaders: any[] = [];
+
+  constructor(private fb: FirebaseService) {}
+
+  async ngOnInit() {
+    this.leaders = await this.fb.getLeaderboard();
+  }
+}

--- a/src/app/mental-status/mental-status.page.ts
+++ b/src/app/mental-status/mental-status.page.ts
@@ -48,9 +48,11 @@ export class MentalStatusPage {
 
   async submit() {
     const user = this.fb.auth.currentUser;
+    const parentId = user ? await this.fb.getParentIdForChild(user.uid) : null;
     await this.fb.saveMentalStatus({
       ...this.form,
       userId: user ? user.uid : null,
+      parentId,
       date: new Date().toISOString(),
     });
     console.log('Mental status saved');


### PR DESCRIPTION
## Summary
- notify parents when mental health concerns are submitted
- track daily check-in streaks and milestone points
- maintain a leaderboard using user stats
- capture child age during child account creation
- add a link to the leaderboard in the home page

## Testing
- `npm test` *(fails: ng not found)*
- `npx tsc -p tsconfig.json` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685a2a73b04883279d603e50cf77f3d2