### PR TITLE
Add typed interfaces and update Firebase service

### DIFF
--- a/src/app/academic-progress/academic-progress.page.ts
+++ b/src/app/academic-progress/academic-progress.page.ts
@@ -13,6 +13,7 @@ import {
   IonButton,
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
+import { AcademicProgressEntry } from '../models/academic-progress';
 
 @Component({
   selector: 'app-academic-progress',
@@ -34,7 +35,7 @@ import { FirebaseService } from '../services/firebase.service';
   styleUrls: ['./academic-progress.page.scss'],
 })
 export class AcademicProgressPage {
-  form = {
+  form: Omit<AcademicProgressEntry, 'userId' | 'date'> = {
     testScore: null as number | null,
     shareResult: false,
     needsHelp: false,

--- a/src/app/bible-quiz/bible-quiz.page.ts
+++ b/src/app/bible-quiz/bible-quiz.page.ts
@@ -13,6 +13,7 @@ import {
   IonButton,
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
+import { BibleQuestion } from '../models/bible-quiz';
 
 @Component({
   selector: 'app-bible-quiz',
@@ -34,7 +35,7 @@ import { FirebaseService } from '../services/firebase.service';
   styleUrls: ['./bible-quiz.page.scss'],
 })
 export class BibleQuizPage implements OnInit {
-  question: any = null;
+  question: BibleQuestion | null = null;
   answer = '';
 
   constructor(private fb: FirebaseService) {}

--- a/src/app/check-in/check-in.page.ts
+++ b/src/app/check-in/check-in.page.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonTextarea, IonSegment, IonSegmentButton } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
+import { DailyCheckin } from '../models/daily-checkin';
 
 @Component({
   selector: 'app-check-in',
@@ -27,7 +28,7 @@ import { FirebaseService } from '../services/firebase.service';
   styleUrls: ['./check-in.page.scss'],
 })
 export class CheckInPage {
-  form = {
+  form: Omit<DailyCheckin, 'userId' | 'parentId' | 'date'> = {
     gratitude1: '',
     gratitude2: '',
     gratitude3: '',

--- a/src/app/essay-tracker/essay-tracker.page.ts
+++ b/src/app/essay-tracker/essay-tracker.page.ts
@@ -15,6 +15,7 @@ import {
   IonSelectOption,
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
+import { EssayEntry } from '../models/essay-entry';
 
 @Component({
   selector: 'app-essay-tracker',
@@ -38,7 +39,7 @@ import { FirebaseService } from '../services/firebase.service';
   styleUrls: ['./essay-tracker.page.scss'],
 })
 export class EssayTrackerPage {
-  form = {
+  form: Omit<EssayEntry, 'userId' | 'date'> = {
     title: '',
     progress: 'in progress',
     needHelp: false,

--- a/src/app/leaderboard/leaderboard.page.ts
+++ b/src/app/leaderboard/leaderboard.page.ts
@@ -10,6 +10,7 @@ import {
   IonLabel,
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
+import { LeaderboardEntry } from '../models/user-stats';
 
 @Component({
   selector: 'app-leaderboard',
@@ -28,7 +29,7 @@ import { FirebaseService } from '../services/firebase.service';
   styleUrls: ['./leaderboard.page.scss'],
 })
 export class LeaderboardPage implements OnInit {
-  leaders: any[] = [];
+  leaders: LeaderboardEntry[] = [];
 
   constructor(private fb: FirebaseService) {}
 

--- a/src/app/mental-status/mental-status.page.ts
+++ b/src/app/mental-status/mental-status.page.ts
@@ -14,6 +14,7 @@ import {
   IonTextarea,
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
+import { MentalStatus } from '../models/mental-status';
 
 @Component({
   selector: 'app-mental-status',
@@ -36,7 +37,7 @@ import { FirebaseService } from '../services/firebase.service';
   styleUrls: ['./mental-status.page.scss'],
 })
 export class MentalStatusPage {
-  form = {
+  form: Omit<MentalStatus, 'userId' | 'parentId' | 'date'> = {
     treatmentSchool: false,
     treatmentHome: false,
     bullied: false,

--- a/src/app/models/academic-progress.ts
+++ b/src/app/models/academic-progress.ts
@@ -1,0 +1,7 @@
+export interface AcademicProgressEntry {
+  testScore: number | null;
+  shareResult: boolean;
+  needsHelp: boolean;
+  userId?: string | null;
+  date: string;
+}

--- a/src/app/models/bible-quiz.ts
+++ b/src/app/models/bible-quiz.ts
@@ -1,0 +1,12 @@
+export interface BibleQuestion {
+  id?: string;
+  text: string;
+}
+
+export interface BibleQuizResult {
+  question: BibleQuestion;
+  answer: string;
+  score: number;
+  userId?: string | null;
+  date: string;
+}

--- a/src/app/models/daily-checkin.ts
+++ b/src/app/models/daily-checkin.ts
@@ -1,0 +1,16 @@
+export interface DailyCheckin {
+  gratitude1: string;
+  gratitude2: string;
+  gratitude3: string;
+  wish: string;
+  goal: string;
+  birthday: string;
+  mood: string;
+  sleepQuality: string;
+  appetite: string;
+  treatment: string;
+  needsHelp: boolean;
+  userId?: string | null;
+  parentId?: string | null;
+  date: string;
+}

--- a/src/app/models/essay-entry.ts
+++ b/src/app/models/essay-entry.ts
@@ -1,0 +1,7 @@
+export interface EssayEntry {
+  title: string;
+  progress: string;
+  needHelp: boolean;
+  userId?: string | null;
+  date: string;
+}

--- a/src/app/models/mental-status.ts
+++ b/src/app/models/mental-status.ts
@@ -1,0 +1,10 @@
+export interface MentalStatus {
+  treatmentSchool: boolean;
+  treatmentHome: boolean;
+  bullied: boolean;
+  notifyParent: boolean;
+  suggestions: string;
+  userId?: string | null;
+  parentId?: string | null;
+  date: string;
+}

--- a/src/app/models/parent-child-link.ts
+++ b/src/app/models/parent-child-link.ts
@@ -1,0 +1,4 @@
+export interface ParentChildLink {
+  parentId: string;
+  childId: string;
+}

--- a/src/app/models/project-entry.ts
+++ b/src/app/models/project-entry.ts
@@ -1,0 +1,8 @@
+export interface ProjectEntry {
+  title: string;
+  presentationDate: string;
+  needsHelp: boolean;
+  enjoyment: number;
+  userId?: string | null;
+  date: string;
+}

--- a/src/app/models/user-stats.ts
+++ b/src/app/models/user-stats.ts
@@ -1,0 +1,9 @@
+export interface UserStats {
+  streak: number;
+  lastCheckInDate: string;
+  points: number;
+}
+
+export interface LeaderboardEntry extends UserStats {
+  id: string;
+}

--- a/src/app/project-tracker/project-tracker.page.ts
+++ b/src/app/project-tracker/project-tracker.page.ts
@@ -13,6 +13,7 @@ import {
   IonButton,
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
+import { ProjectEntry } from '../models/project-entry';
 
 @Component({
   selector: 'app-project-tracker',
@@ -34,7 +35,7 @@ import { FirebaseService } from '../services/firebase.service';
   styleUrls: ['./project-tracker.page.scss'],
 })
 export class ProjectTrackerPage {
-  form = {
+  form: Omit<ProjectEntry, 'userId' | 'date'> = {
     title: '',
     presentationDate: '',
     needsHelp: false,


### PR DESCRIPTION
## Summary
- introduce TypeScript interfaces for data models
- use typed models in Firebase service and pages
- remove `any` usages

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad534e8ec8327a804bc319c4c9a99