### PR TITLE
Fix bible question return type

### DIFF
--- a/src/app/services/firebase.service.ts
+++ b/src/app/services/firebase.service.ts
@@ -117,7 +117,10 @@ export class FirebaseService {
       return null;
     }
     const random = Math.floor(Math.random() * docs.length);
-    return { id: docs[random].id, ...docs[random].data() };
+    return {
+      id: docs[random].id,
+      ...(docs[random].data() as Omit<BibleQuestion, 'id'>),
+    } as BibleQuestion;
   }
 
   async sendNotification(parentId: string, message: string) {


### PR DESCRIPTION
## Summary
- ensure returned bible question has all required fields

## Testing
- `npm test -- --no-watch --no-progress` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad722444883279ad4fb9f32d5d1b6