### PR TITLE
Fix bible quiz submission when question missing

### DIFF
--- a/src/app/bible-quiz/bible-quiz.page.ts
+++ b/src/app/bible-quiz/bible-quiz.page.ts
@@ -45,9 +45,13 @@ export class BibleQuizPage implements OnInit {
   }
 
   async submit() {
+    if (!this.question) {
+      console.error('No quiz question available');
+      return;
+    }
     const user = this.fb.auth.currentUser;
     await this.fb.saveBibleQuiz({
-      question: this.question,
+      question: this.question!,
       answer: this.answer,
       score: 200,
       userId: user ? user.uid : null,


### PR DESCRIPTION
## Summary
- ensure bible quiz submission checks for question presence

## Testing
- `npm test --silent -- -c --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad8f5633883278633b2964045903e