### PR TITLE
Add project tracker validation and progress

### DIFF
--- a/src/app/models/project-entry.ts
+++ b/src/app/models/project-entry.ts
@@ -3,6 +3,8 @@ export interface ProjectEntry {
   presentationDate: string;
   needsHelp: boolean;
   enjoyment: number;
+  progress: string;
+  quarter: string;
   userId?: string | null;
   date: string;
 }

--- a/src/app/project-tracker/project-tracker.page.html
+++ b/src/app/project-tracker/project-tracker.page.html
@@ -8,19 +8,27 @@
   <ion-list>
     <ion-item>
       <ion-label position="stacked">Project Title</ion-label>
-      <ion-input [(ngModel)]="form.title"></ion-input>
+      <ion-input [(ngModel)]="form.title" required></ion-input>
     </ion-item>
     <ion-item>
       <ion-label position="stacked">Presentation Date</ion-label>
-      <ion-input type="date" [(ngModel)]="form.presentationDate"></ion-input>
+      <ion-input type="date" [(ngModel)]="form.presentationDate" required></ion-input>
     </ion-item>
     <ion-item>
       <ion-label>Need Help?</ion-label>
-      <ion-input type="checkbox" [(ngModel)]="form.needsHelp"></ion-input>
+      <ion-checkbox [(ngModel)]="form.needsHelp"></ion-checkbox>
     </ion-item>
     <ion-item>
       <ion-label position="stacked">Enjoyment (1-5)</ion-label>
-      <ion-input type="number" min="1" max="5" [(ngModel)]="form.enjoyment"></ion-input>
+      <ion-input type="number" min="1" max="5" [(ngModel)]="form.enjoyment" required></ion-input>
+    </ion-item>
+    <ion-item>
+      <ion-label position="stacked">Progress</ion-label>
+      <ion-select [(ngModel)]="form.progress">
+        <ion-select-option value="not started">Not Started</ion-select-option>
+        <ion-select-option value="in progress">In Progress</ion-select-option>
+        <ion-select-option value="completed">Completed</ion-select-option>
+      </ion-select>
     </ion-item>
   </ion-list>
   <div class="ion-padding">

--- a/src/app/project-tracker/project-tracker.page.ts
+++ b/src/app/project-tracker/project-tracker.page.ts
@@ -11,6 +11,9 @@ import {
   IonInput,
   IonList,
   IonButton,
+  IonCheckbox,
+  IonSelect,
+  IonSelectOption,
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { ProjectEntry } from '../models/project-entry';
@@ -30,27 +33,53 @@ import { ProjectEntry } from '../models/project-entry';
     IonInput,
     IonList,
     IonButton,
+    IonCheckbox,
+    IonSelect,
+    IonSelectOption,
   ],
   templateUrl: './project-tracker.page.html',
   styleUrls: ['./project-tracker.page.scss'],
 })
 export class ProjectTrackerPage {
-  form: Omit<ProjectEntry, 'userId' | 'date'> = {
+  form: Omit<ProjectEntry, 'userId' | 'date' | 'quarter'> = {
     title: '',
     presentationDate: '',
     needsHelp: false,
     enjoyment: 3,
+    progress: 'in progress',
   };
 
   constructor(private fb: FirebaseService) {}
 
   async submit() {
+    if (!this.form.title || !this.form.presentationDate || !this.form.enjoyment) {
+      alert('Please fill in all required fields');
+      return;
+    }
     const user = this.fb.auth.currentUser;
+    const quarter = this.getQuarter(this.form.presentationDate);
     await this.fb.saveProject({
       ...this.form,
+      quarter,
       userId: user ? user.uid : null,
       date: new Date().toISOString(),
     });
     console.log('Project saved');
+    this.form = {
+      title: '',
+      presentationDate: '',
+      needsHelp: false,
+      enjoyment: 3,
+      progress: 'in progress',
+    };
+  }
+
+  private getQuarter(dateStr: string): string {
+    if (!dateStr) {
+      return '';
+    }
+    const month = new Date(dateStr).getMonth();
+    const q = Math.floor(month / 3) + 1;
+    return `Q${q}`;
   }
 }


### PR DESCRIPTION
## Summary
- extend `ProjectEntry` model with `progress` and `quarter`
- update project tracker component to use `ion-checkbox`
- add progress selector and validation
- reset the form and compute quarter on submit

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aedd52e6883279c89ee9074d568e8