### PR TITLE
Fix missing Ionicons in tabs

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,31 @@
 import { bootstrapApplication } from '@angular/platform-browser';
-import { RouteReuseStrategy, provideRouter, withPreloading, PreloadAllModules } from '@angular/router';
-import { IonicRouteStrategy, provideIonicAngular } from '@ionic/angular/standalone';
+import {
+  RouteReuseStrategy,
+  provideRouter,
+  withPreloading,
+  PreloadAllModules,
+} from '@angular/router';
+import {
+  IonicRouteStrategy,
+  provideIonicAngular,
+} from '@ionic/angular/standalone';
+import { addIcons } from 'ionicons';
+import {
+  calendarOutline,
+  helpOutline,
+  createOutline,
+  listOutline,
+} from 'ionicons/icons';
 
 import { routes } from './app/app.routes';
 import { AppComponent } from './app/app.component';
+
+addIcons({
+  calendarOutline,
+  helpOutline,
+  createOutline,
+  listOutline,
+});
 
 bootstrapApplication(AppComponent, {
   providers: [


### PR DESCRIPTION
## Summary
- register missing icons used in tabs page

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aef6283008327b9f464e5de3cf175