### PR TITLE
Fix pages unclickable by adding IonPage wrappers

### DIFF
--- a/src/app/academic-progress/academic-progress.page.html
+++ b/src/app/academic-progress/academic-progress.page.html
@@ -1,10 +1,11 @@
-<ion-header>
-  <ion-toolbar>
-    <ion-title>Academic Progress</ion-title>
-  </ion-toolbar>
-</ion-header>
+<ion-page>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Academic Progress</ion-title>
+    </ion-toolbar>
+  </ion-header>
 
-<ion-content>
+  <ion-content>
   <ion-list>
     <ion-item>
       <ion-label position="stacked">Test Score</ion-label>
@@ -22,4 +23,5 @@
   <div class="ion-padding">
     <ion-button expand="block" (click)="submit()">Submit</ion-button>
   </div>
-</ion-content>
+  </ion-content>
+</ion-page>

--- a/src/app/academic-progress/academic-progress.page.ts
+++ b/src/app/academic-progress/academic-progress.page.ts
@@ -11,6 +11,7 @@ import {
   IonInput,
   IonList,
   IonButton,
+  IonPage,
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { AcademicProgressEntry } from '../models/academic-progress';
@@ -21,6 +22,7 @@ import { AcademicProgressEntry } from '../models/academic-progress';
   imports: [
     CommonModule,
     FormsModule,
+    IonPage,
     IonHeader,
     IonToolbar,
     IonTitle,

--- a/src/app/bible-quiz/bible-quiz.page.html
+++ b/src/app/bible-quiz/bible-quiz.page.html
@@ -1,10 +1,11 @@
-<ion-header>
-  <ion-toolbar>
-    <ion-title>Bible Quiz</ion-title>
-  </ion-toolbar>
-</ion-header>
+<ion-page>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Bible Quiz</ion-title>
+    </ion-toolbar>
+  </ion-header>
 
-<ion-content>
+  <ion-content>
   <ion-list *ngIf="question">
     <ion-item>
       <ion-label position="stacked">Question</ion-label>
@@ -18,4 +19,5 @@
   <div class="ion-padding">
     <ion-button expand="block" (click)="submit()">Submit</ion-button>
   </div>
-</ion-content>
+  </ion-content>
+</ion-page>

--- a/src/app/bible-quiz/bible-quiz.page.ts
+++ b/src/app/bible-quiz/bible-quiz.page.ts
@@ -11,6 +11,7 @@ import {
   IonInput,
   IonList,
   IonButton,
+  IonPage,
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { BibleQuestion } from '../models/bible-quiz';
@@ -21,6 +22,7 @@ import { BibleQuestion } from '../models/bible-quiz';
   imports: [
     CommonModule,
     FormsModule,
+    IonPage,
     IonHeader,
     IonToolbar,
     IonTitle,

--- a/src/app/check-in/check-in.page.html
+++ b/src/app/check-in/check-in.page.html
@@ -1,10 +1,11 @@
-<ion-header>
-  <ion-toolbar>
-    <ion-title>Daily Check-In</ion-title>
-  </ion-toolbar>
-</ion-header>
+<ion-page>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Daily Check-In</ion-title>
+    </ion-toolbar>
+  </ion-header>
 
-<ion-content>
+  <ion-content>
   <ion-list>
     <ion-item>
       <ion-label position="stacked">Gratitude 1</ion-label>
@@ -70,4 +71,5 @@
   <div class="ion-padding">
     <ion-button expand="block" (click)="submit()">Submit</ion-button>
   </div>
-</ion-content>
+  </ion-content>
+</ion-page>

--- a/src/app/check-in/check-in.page.ts
+++ b/src/app/check-in/check-in.page.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonTextarea, IonSegment, IonSegmentButton } from '@ionic/angular/standalone';
+import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonTextarea, IonSegment, IonSegmentButton, IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { DailyCheckin } from '../models/daily-checkin';
 
@@ -11,6 +11,7 @@ import { DailyCheckin } from '../models/daily-checkin';
   imports: [
     CommonModule,
     FormsModule,
+    IonPage,
     IonHeader,
     IonToolbar,
     IonTitle,

--- a/src/app/child-account/child-account.page.html
+++ b/src/app/child-account/child-account.page.html
@@ -1,10 +1,11 @@
-<ion-header>
-  <ion-toolbar>
-    <ion-title>Create Child Account</ion-title>
-  </ion-toolbar>
-</ion-header>
+<ion-page>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Create Child Account</ion-title>
+    </ion-toolbar>
+  </ion-header>
 
-<ion-content class="ion-padding">
+  <ion-content class="ion-padding">
   <ion-list>
     <ion-item>
       <ion-label position="stacked">Child Email</ion-label>
@@ -20,4 +21,5 @@
     </ion-item>
   </ion-list>
   <ion-button expand="block" (click)="create()">Create</ion-button>
-</ion-content>
+  </ion-content>
+</ion-page>

--- a/src/app/child-account/child-account.page.ts
+++ b/src/app/child-account/child-account.page.ts
@@ -1,14 +1,27 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList } from '@ionic/angular/standalone';
+import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-child-account',
   standalone: true,
-  imports: [CommonModule, FormsModule, IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList],
+  imports: [
+    CommonModule,
+    FormsModule,
+    IonPage,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
+    IonContent,
+    IonInput,
+    IonItem,
+    IonLabel,
+    IonButton,
+    IonList,
+  ],
   templateUrl: './child-account.page.html',
   styleUrls: ['./child-account.page.scss'],
 })

--- a/src/app/essay-tracker/essay-tracker.page.html
+++ b/src/app/essay-tracker/essay-tracker.page.html
@@ -1,10 +1,11 @@
-<ion-header>
-  <ion-toolbar>
-    <ion-title>Essay Tracker</ion-title>
-  </ion-toolbar>
-</ion-header>
+<ion-page>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Essay Tracker</ion-title>
+    </ion-toolbar>
+  </ion-header>
 
-<ion-content>
+  <ion-content>
   <ion-list>
     <ion-item>
       <ion-label position="stacked">Essay Title</ion-label>
@@ -26,4 +27,5 @@
   <div class="ion-padding">
     <ion-button expand="block" (click)="submit()">Submit</ion-button>
   </div>
-</ion-content>
+  </ion-content>
+</ion-page>

--- a/src/app/essay-tracker/essay-tracker.page.ts
+++ b/src/app/essay-tracker/essay-tracker.page.ts
@@ -13,6 +13,7 @@ import {
   IonButton,
   IonSelect,
   IonSelectOption,
+  IonPage,
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { EssayEntry } from '../models/essay-entry';
@@ -23,6 +24,7 @@ import { EssayEntry } from '../models/essay-entry';
   imports: [
     CommonModule,
     FormsModule,
+    IonPage,
     IonHeader,
     IonToolbar,
     IonTitle,

--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -1,28 +1,30 @@
-<ion-header [translucent]="true">
-  <ion-toolbar>
-    <ion-title>
-      Kids Faith Tracker
-    </ion-title>
-  </ion-toolbar>
-</ion-header>
-
-<ion-content [fullscreen]="true">
-  <ion-header collapse="condense">
+<ion-page>
+  <ion-header [translucent]="true">
     <ion-toolbar>
-      <ion-title size="large">Blank</ion-title>
+      <ion-title>
+        Kids Faith Tracker
+      </ion-title>
     </ion-toolbar>
   </ion-header>
 
-  <div class="ion-padding">
-    <ion-button routerLink="/check-in" expand="block">Daily Check-In</ion-button>
-    <ion-button routerLink="/login" expand="block">Login</ion-button>
-    <ion-button routerLink="/register" expand="block">Register</ion-button>
-    <ion-button routerLink="/child-account" expand="block">Create Child</ion-button>
-    <ion-button routerLink="/mental-status" expand="block">Mental Status</ion-button>
-    <ion-button routerLink="/bible-quiz" expand="block">Bible Quiz</ion-button>
-    <ion-button routerLink="/essay-tracker" expand="block">Essay Tracker</ion-button>
-    <ion-button routerLink="/academic-progress" expand="block">Academic Progress</ion-button>
-    <ion-button routerLink="/project-tracker" expand="block">Project Tracker</ion-button>
-    <ion-button routerLink="/leaderboard" expand="block">Leaderboard</ion-button>
-  </div>
-</ion-content>
+  <ion-content [fullscreen]="true">
+    <ion-header collapse="condense">
+      <ion-toolbar>
+        <ion-title size="large">Blank</ion-title>
+      </ion-toolbar>
+    </ion-header>
+
+    <div class="ion-padding">
+      <ion-button routerLink="/check-in" expand="block">Daily Check-In</ion-button>
+      <ion-button routerLink="/login" expand="block">Login</ion-button>
+      <ion-button routerLink="/register" expand="block">Register</ion-button>
+      <ion-button routerLink="/child-account" expand="block">Create Child</ion-button>
+      <ion-button routerLink="/mental-status" expand="block">Mental Status</ion-button>
+      <ion-button routerLink="/bible-quiz" expand="block">Bible Quiz</ion-button>
+      <ion-button routerLink="/essay-tracker" expand="block">Essay Tracker</ion-button>
+      <ion-button routerLink="/academic-progress" expand="block">Academic Progress</ion-button>
+      <ion-button routerLink="/project-tracker" expand="block">Project Tracker</ion-button>
+      <ion-button routerLink="/leaderboard" expand="block">Leaderboard</ion-button>
+    </div>
+  </ion-content>
+</ion-page>

--- a/src/app/home/home.page.ts
+++ b/src/app/home/home.page.ts
@@ -1,12 +1,12 @@
 import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { IonHeader, IonToolbar, IonTitle, IonContent, IonButton } from '@ionic/angular/standalone';
+import { IonHeader, IonToolbar, IonTitle, IonContent, IonButton, IonPage } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-home',
   templateUrl: 'home.page.html',
   styleUrls: ['home.page.scss'],
-  imports: [IonHeader, IonToolbar, IonTitle, IonContent, IonButton, RouterLink],
+  imports: [IonPage, IonHeader, IonToolbar, IonTitle, IonContent, IonButton, RouterLink],
 })
 export class HomePage {
   constructor() {}

--- a/src/app/leaderboard/leaderboard.page.html
+++ b/src/app/leaderboard/leaderboard.page.html
@@ -1,13 +1,15 @@
-<ion-header>
-  <ion-toolbar>
-    <ion-title>Leaderboard</ion-title>
-  </ion-toolbar>
-</ion-header>
+<ion-page>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Leaderboard</ion-title>
+    </ion-toolbar>
+  </ion-header>
 
-<ion-content>
+  <ion-content>
   <ion-list>
     <ion-item *ngFor="let item of leaders; let i = index">
       <ion-label>{{ i + 1 }}. {{ item.id }} - {{ item.points }} pts (Streak: {{ item.streak || 0 }})</ion-label>
     </ion-item>
   </ion-list>
-</ion-content>
+  </ion-content>
+</ion-page>

--- a/src/app/leaderboard/leaderboard.page.ts
+++ b/src/app/leaderboard/leaderboard.page.ts
@@ -8,6 +8,7 @@ import {
   IonList,
   IonItem,
   IonLabel,
+  IonPage,
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { LeaderboardEntry } from '../models/user-stats';
@@ -17,6 +18,7 @@ import { LeaderboardEntry } from '../models/user-stats';
   standalone: true,
   imports: [
     CommonModule,
+    IonPage,
     IonHeader,
     IonToolbar,
     IonTitle,

--- a/src/app/login/login.page.html
+++ b/src/app/login/login.page.html
@@ -1,10 +1,11 @@
-<ion-header>
-  <ion-toolbar>
-    <ion-title>Login</ion-title>
-  </ion-toolbar>
-</ion-header>
+<ion-page>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Login</ion-title>
+    </ion-toolbar>
+  </ion-header>
 
-<ion-content class="ion-padding">
+  <ion-content class="ion-padding">
   <ion-list>
     <ion-item>
       <ion-label position="stacked">Email</ion-label>
@@ -23,4 +24,5 @@
     </ion-item>
   </ion-list>
   <ion-button expand="block" (click)="login()">Login</ion-button>
-</ion-content>
+  </ion-content>
+</ion-page>

--- a/src/app/login/login.page.ts
+++ b/src/app/login/login.page.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonSelect, IonSelectOption } from '@ionic/angular/standalone';
+import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonSelect, IonSelectOption, IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
 import { RoleService } from '../services/role.service';
@@ -12,6 +12,7 @@ import { RoleService } from '../services/role.service';
   imports: [
     CommonModule,
     FormsModule,
+    IonPage,
     IonHeader,
     IonToolbar,
     IonTitle,

--- a/src/app/mental-status/mental-status.page.html
+++ b/src/app/mental-status/mental-status.page.html
@@ -1,10 +1,11 @@
-<ion-header>
-  <ion-toolbar>
-    <ion-title>Mental & Emotional Status</ion-title>
-  </ion-toolbar>
-</ion-header>
+<ion-page>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Mental & Emotional Status</ion-title>
+    </ion-toolbar>
+  </ion-header>
 
-<ion-content>
+  <ion-content>
   <ion-list>
     <ion-item>
       <ion-label>Well Treated at School</ion-label>
@@ -30,4 +31,5 @@
   <div class="ion-padding">
     <ion-button expand="block" (click)="submit()">Submit</ion-button>
   </div>
-</ion-content>
+  </ion-content>
+</ion-page>

--- a/src/app/mental-status/mental-status.page.ts
+++ b/src/app/mental-status/mental-status.page.ts
@@ -12,6 +12,7 @@ import {
   IonList,
   IonButton,
   IonTextarea,
+  IonPage,
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { MentalStatus } from '../models/mental-status';
@@ -22,6 +23,7 @@ import { MentalStatus } from '../models/mental-status';
   imports: [
     CommonModule,
     FormsModule,
+    IonPage,
     IonHeader,
     IonToolbar,
     IonTitle,

--- a/src/app/project-tracker/project-tracker.page.html
+++ b/src/app/project-tracker/project-tracker.page.html
@@ -1,10 +1,11 @@
-<ion-header>
-  <ion-toolbar>
-    <ion-title>Project Tracker</ion-title>
-  </ion-toolbar>
-</ion-header>
+<ion-page>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Project Tracker</ion-title>
+    </ion-toolbar>
+  </ion-header>
 
-<ion-content>
+  <ion-content>
   <ion-list>
     <ion-item>
       <ion-label position="stacked">Project Title</ion-label>
@@ -34,4 +35,5 @@
   <div class="ion-padding">
     <ion-button expand="block" (click)="submit()">Submit</ion-button>
   </div>
-</ion-content>
+  </ion-content>
+</ion-page>

--- a/src/app/project-tracker/project-tracker.page.ts
+++ b/src/app/project-tracker/project-tracker.page.ts
@@ -14,6 +14,7 @@ import {
   IonCheckbox,
   IonSelect,
   IonSelectOption,
+  IonPage,
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { ProjectEntry } from '../models/project-entry';
@@ -24,6 +25,7 @@ import { ProjectEntry } from '../models/project-entry';
   imports: [
     CommonModule,
     FormsModule,
+    IonPage,
     IonHeader,
     IonToolbar,
     IonTitle,

--- a/src/app/register/register.page.html
+++ b/src/app/register/register.page.html
@@ -1,10 +1,11 @@
-<ion-header>
-  <ion-toolbar>
-    <ion-title>Register</ion-title>
-  </ion-toolbar>
-</ion-header>
+<ion-page>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Register</ion-title>
+    </ion-toolbar>
+  </ion-header>
 
-<ion-content class="ion-padding">
+  <ion-content class="ion-padding">
   <ion-list>
     <ion-item>
       <ion-label position="stacked">Email</ion-label>
@@ -16,4 +17,5 @@
     </ion-item>
   </ion-list>
   <ion-button expand="block" (click)="register()">Register</ion-button>
-</ion-content>
+  </ion-content>
+</ion-page>

--- a/src/app/register/register.page.ts
+++ b/src/app/register/register.page.ts
@@ -1,14 +1,27 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList } from '@ionic/angular/standalone';
+import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-register',
   standalone: true,
-  imports: [CommonModule, FormsModule, IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList],
+  imports: [
+    CommonModule,
+    FormsModule,
+    IonPage,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
+    IonContent,
+    IonInput,
+    IonItem,
+    IonLabel,
+    IonButton,
+    IonList,
+  ],
   templateUrl: './register.page.html',
   styleUrls: ['./register.page.scss'],
 })

--- a/src/app/tabs/tabs.page.html
+++ b/src/app/tabs/tabs.page.html
@@ -1,3 +1,4 @@
+<ion-page>
 <ion-tabs>
   <ion-router-outlet></ion-router-outlet>
   <ion-tab-bar slot="bottom">
@@ -35,3 +36,4 @@
     </ng-template>
   </ion-tab-bar>
 </ion-tabs>
+</ion-page>

--- a/src/app/tabs/tabs.page.ts
+++ b/src/app/tabs/tabs.page.ts
@@ -7,6 +7,7 @@ import {
   IonIcon,
   IonLabel,
   IonRouterOutlet,
+  IonPage,
 } from '@ionic/angular/standalone';
 import { RouterLink, RouterOutlet } from '@angular/router';
 import { RoleService } from '../services/role.service';
@@ -18,6 +19,7 @@ import { RoleService } from '../services/role.service';
     CommonModule,
     RouterOutlet,
     RouterLink,
+    IonPage,
     IonTabs,
     IonTabBar,
     IonTabButton,


### PR DESCRIPTION
## Summary
- wrap routed pages in `<ion-page>`
- import `IonPage` in standalone components to enable pointer events

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685af11ad0208327a55a9abb62f95e7f