### PR TITLE
Fix IonPage compilation errors

### DIFF
--- a/src/app/academic-progress/academic-progress.page.ts
+++ b/src/app/academic-progress/academic-progress.page.ts
@@ -11,7 +11,6 @@ import {
   IonInput,
   IonList,
   IonButton,
-  IonPage,
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { AcademicProgressEntry } from '../models/academic-progress';
@@ -22,7 +21,6 @@ import { AcademicProgressEntry } from '../models/academic-progress';
   imports: [
     CommonModule,
     FormsModule,
-    IonPage,
     IonHeader,
     IonToolbar,
     IonTitle,

--- a/src/app/bible-quiz/bible-quiz.page.ts
+++ b/src/app/bible-quiz/bible-quiz.page.ts
@@ -11,7 +11,6 @@ import {
   IonInput,
   IonList,
   IonButton,
-  IonPage,
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { BibleQuestion } from '../models/bible-quiz';
@@ -22,7 +21,6 @@ import { BibleQuestion } from '../models/bible-quiz';
   imports: [
     CommonModule,
     FormsModule,
-    IonPage,
     IonHeader,
     IonToolbar,
     IonTitle,

--- a/src/app/check-in/check-in.page.ts
+++ b/src/app/check-in/check-in.page.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonTextarea, IonSegment, IonSegmentButton, IonPage } from '@ionic/angular/standalone';
+import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonTextarea, IonSegment, IonSegmentButton } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { DailyCheckin } from '../models/daily-checkin';
 
@@ -11,7 +11,6 @@ import { DailyCheckin } from '../models/daily-checkin';
   imports: [
     CommonModule,
     FormsModule,
-    IonPage,
     IonHeader,
     IonToolbar,
     IonTitle,

--- a/src/app/child-account/child-account.page.ts
+++ b/src/app/child-account/child-account.page.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonPage } from '@ionic/angular/standalone';
+import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
 
@@ -11,7 +11,6 @@ import { Router } from '@angular/router';
   imports: [
     CommonModule,
     FormsModule,
-    IonPage,
     IonHeader,
     IonToolbar,
     IonTitle,

--- a/src/app/essay-tracker/essay-tracker.page.ts
+++ b/src/app/essay-tracker/essay-tracker.page.ts
@@ -13,7 +13,6 @@ import {
   IonButton,
   IonSelect,
   IonSelectOption,
-  IonPage,
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { EssayEntry } from '../models/essay-entry';
@@ -24,7 +23,6 @@ import { EssayEntry } from '../models/essay-entry';
   imports: [
     CommonModule,
     FormsModule,
-    IonPage,
     IonHeader,
     IonToolbar,
     IonTitle,

--- a/src/app/home/home.page.ts
+++ b/src/app/home/home.page.ts
@@ -1,12 +1,13 @@
 import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { IonHeader, IonToolbar, IonTitle, IonContent, IonButton, IonPage } from '@ionic/angular/standalone';
+import { IonHeader, IonToolbar, IonTitle, IonContent, IonButton } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-home',
   templateUrl: 'home.page.html',
   styleUrls: ['home.page.scss'],
-  imports: [IonPage, IonHeader, IonToolbar, IonTitle, IonContent, IonButton, RouterLink],
+  standalone: true,
+  imports: [IonHeader, IonToolbar, IonTitle, IonContent, IonButton, RouterLink],
 })
 export class HomePage {
   constructor() {}

--- a/src/app/leaderboard/leaderboard.page.ts
+++ b/src/app/leaderboard/leaderboard.page.ts
@@ -8,7 +8,6 @@ import {
   IonList,
   IonItem,
   IonLabel,
-  IonPage,
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { LeaderboardEntry } from '../models/user-stats';
@@ -18,7 +17,6 @@ import { LeaderboardEntry } from '../models/user-stats';
   standalone: true,
   imports: [
     CommonModule,
-    IonPage,
     IonHeader,
     IonToolbar,
     IonTitle,

--- a/src/app/login/login.page.ts
+++ b/src/app/login/login.page.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonSelect, IonSelectOption, IonPage } from '@ionic/angular/standalone';
+import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonSelect, IonSelectOption } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
 import { RoleService } from '../services/role.service';
@@ -12,7 +12,6 @@ import { RoleService } from '../services/role.service';
   imports: [
     CommonModule,
     FormsModule,
-    IonPage,
     IonHeader,
     IonToolbar,
     IonTitle,

--- a/src/app/mental-status/mental-status.page.ts
+++ b/src/app/mental-status/mental-status.page.ts
@@ -12,7 +12,6 @@ import {
   IonList,
   IonButton,
   IonTextarea,
-  IonPage,
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { MentalStatus } from '../models/mental-status';
@@ -23,7 +22,6 @@ import { MentalStatus } from '../models/mental-status';
   imports: [
     CommonModule,
     FormsModule,
-    IonPage,
     IonHeader,
     IonToolbar,
     IonTitle,

--- a/src/app/project-tracker/project-tracker.page.ts
+++ b/src/app/project-tracker/project-tracker.page.ts
@@ -14,7 +14,6 @@ import {
   IonCheckbox,
   IonSelect,
   IonSelectOption,
-  IonPage,
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { ProjectEntry } from '../models/project-entry';
@@ -25,7 +24,6 @@ import { ProjectEntry } from '../models/project-entry';
   imports: [
     CommonModule,
     FormsModule,
-    IonPage,
     IonHeader,
     IonToolbar,
     IonTitle,

--- a/src/app/register/register.page.ts
+++ b/src/app/register/register.page.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonPage } from '@ionic/angular/standalone';
+import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
 
@@ -11,7 +11,6 @@ import { Router } from '@angular/router';
   imports: [
     CommonModule,
     FormsModule,
-    IonPage,
     IonHeader,
     IonToolbar,
     IonTitle,

--- a/src/app/tabs/tabs.page.ts
+++ b/src/app/tabs/tabs.page.ts
@@ -7,7 +7,6 @@ import {
   IonIcon,
   IonLabel,
   IonRouterOutlet,
-  IonPage,
 } from '@ionic/angular/standalone';
 import { RouterLink, RouterOutlet } from '@angular/router';
 import { RoleService } from '../services/role.service';
@@ -18,7 +17,6 @@ import { RoleService } from '../services/role.service';
   imports: [
     CommonModule,
     RouterLink,
-    IonPage,
     IonTabs,
     IonTabBar,
     IonTabButton,


### PR DESCRIPTION
## Summary
- remove IonPage from standalone component imports
- ensure home page declares standalone imports correctly

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685af3585ccc8327b7ae356020d64a61