### PR TITLE
Fix IonPage import paths

### DIFF
--- a/src/app/academic-progress/academic-progress.page.ts
+++ b/src/app/academic-progress/academic-progress.page.ts
@@ -12,7 +12,7 @@ import {
   IonList,
   IonButton,
 } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular';
+import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { AcademicProgressEntry } from '../models/academic-progress';
 

--- a/src/app/bible-quiz/bible-quiz.page.ts
+++ b/src/app/bible-quiz/bible-quiz.page.ts
@@ -12,7 +12,7 @@ import {
   IonList,
   IonButton,
 } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular';
+import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { BibleQuestion } from '../models/bible-quiz';
 

--- a/src/app/check-in/check-in.page.ts
+++ b/src/app/check-in/check-in.page.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import {  IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonTextarea, IonSegment, IonSegmentButton } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular';
+import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { DailyCheckin } from '../models/daily-checkin';
 

--- a/src/app/child-account/child-account.page.ts
+++ b/src/app/child-account/child-account.page.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular';
+import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
 

--- a/src/app/essay-tracker/essay-tracker.page.ts
+++ b/src/app/essay-tracker/essay-tracker.page.ts
@@ -15,7 +15,7 @@ import {
   IonSelect,
   IonSelectOption,
 } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular';
+import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { EssayEntry } from '../models/essay-entry';
 

--- a/src/app/home/home.page.ts
+++ b/src/app/home/home.page.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import {  IonHeader, IonToolbar, IonTitle, IonContent, IonButton } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular';
+import { IonPage } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-home',

--- a/src/app/leaderboard/leaderboard.page.ts
+++ b/src/app/leaderboard/leaderboard.page.ts
@@ -10,7 +10,7 @@ import {
   IonItem,
   IonLabel,
 } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular';
+import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { LeaderboardEntry } from '../models/user-stats';
 

--- a/src/app/login/login.page.ts
+++ b/src/app/login/login.page.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonSelect, IonSelectOption } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular';
+import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
 import { RoleService } from '../services/role.service';

--- a/src/app/mental-status/mental-status.page.ts
+++ b/src/app/mental-status/mental-status.page.ts
@@ -14,7 +14,7 @@ import {
   IonButton,
   IonTextarea,
 } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular';
+import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { MentalStatus } from '../models/mental-status';
 

--- a/src/app/project-tracker/project-tracker.page.ts
+++ b/src/app/project-tracker/project-tracker.page.ts
@@ -15,7 +15,7 @@ import {
   IonSelect,
   IonSelectOption,
 } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular';
+import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { ProjectEntry } from '../models/project-entry';
 

--- a/src/app/register/register.page.ts
+++ b/src/app/register/register.page.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular';
+import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
 

--- a/src/app/tabs/tabs.page.ts
+++ b/src/app/tabs/tabs.page.ts
@@ -9,7 +9,7 @@ import {
   IonLabel,
   IonRouterOutlet,
 } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular';
+import { IonPage } from '@ionic/angular/standalone';
 import { RouterLink, RouterOutlet } from '@angular/router';
 import { RoleService } from '../services/role.service';
 


### PR DESCRIPTION
## Summary
- update IonPage imports to use standalone path

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685afbd973d88327992129163eebdf9b