### PR TITLE
Remove ion-page wrappers

### DIFF
--- a/src/app/academic-progress/academic-progress.page.html
+++ b/src/app/academic-progress/academic-progress.page.html
@@ -1,4 +1,3 @@
-<ion-page>
   <ion-header>
     <ion-toolbar>
       <ion-title>Academic Progress</ion-title>
@@ -24,4 +23,3 @@
     <ion-button expand="block" (click)="submit()">Submit</ion-button>
   </div>
   </ion-content>
-</ion-page>

--- a/src/app/academic-progress/academic-progress.page.ts
+++ b/src/app/academic-progress/academic-progress.page.ts
@@ -12,7 +12,6 @@ import {
   IonList,
   IonButton,
 } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { AcademicProgressEntry } from '../models/academic-progress';
 
@@ -31,7 +30,6 @@ import { AcademicProgressEntry } from '../models/academic-progress';
     IonInput,
     IonList,
     IonButton,
-    IonPage,
   ],
   templateUrl: './academic-progress.page.html',
   styleUrls: ['./academic-progress.page.scss'],

--- a/src/app/bible-quiz/bible-quiz.page.html
+++ b/src/app/bible-quiz/bible-quiz.page.html
@@ -1,4 +1,3 @@
-<ion-page>
   <ion-header>
     <ion-toolbar>
       <ion-title>Bible Quiz</ion-title>
@@ -20,4 +19,3 @@
     <ion-button expand="block" (click)="submit()">Submit</ion-button>
   </div>
   </ion-content>
-</ion-page>

--- a/src/app/bible-quiz/bible-quiz.page.ts
+++ b/src/app/bible-quiz/bible-quiz.page.ts
@@ -12,7 +12,6 @@ import {
   IonList,
   IonButton,
 } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { BibleQuestion } from '../models/bible-quiz';
 
@@ -31,7 +30,6 @@ import { BibleQuestion } from '../models/bible-quiz';
     IonInput,
     IonList,
     IonButton,
-    IonPage,
   ],
   templateUrl: './bible-quiz.page.html',
   styleUrls: ['./bible-quiz.page.scss'],

--- a/src/app/check-in/check-in.page.html
+++ b/src/app/check-in/check-in.page.html
@@ -1,4 +1,3 @@
-<ion-page>
   <ion-header>
     <ion-toolbar>
       <ion-title>Daily Check-In</ion-title>
@@ -72,4 +71,3 @@
     <ion-button expand="block" (click)="submit()">Submit</ion-button>
   </div>
   </ion-content>
-</ion-page>

--- a/src/app/check-in/check-in.page.ts
+++ b/src/app/check-in/check-in.page.ts
@@ -2,7 +2,6 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import {  IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonTextarea, IonSegment, IonSegmentButton } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { DailyCheckin } from '../models/daily-checkin';
 
@@ -24,7 +23,6 @@ import { DailyCheckin } from '../models/daily-checkin';
     IonTextarea,
     IonSegment,
     IonSegmentButton,
-    IonPage,
   ],
   templateUrl: './check-in.page.html',
   styleUrls: ['./check-in.page.scss'],

--- a/src/app/child-account/child-account.page.html
+++ b/src/app/child-account/child-account.page.html
@@ -1,4 +1,3 @@
-<ion-page>
   <ion-header>
     <ion-toolbar>
       <ion-title>Create Child Account</ion-title>
@@ -22,4 +21,3 @@
   </ion-list>
   <ion-button expand="block" (click)="create()">Create</ion-button>
   </ion-content>
-</ion-page>

--- a/src/app/child-account/child-account.page.ts
+++ b/src/app/child-account/child-account.page.ts
@@ -2,7 +2,6 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
 
@@ -21,7 +20,6 @@ import { Router } from '@angular/router';
     IonLabel,
     IonButton,
     IonList,
-    IonPage,
   ],
   templateUrl: './child-account.page.html',
   styleUrls: ['./child-account.page.scss'],

--- a/src/app/essay-tracker/essay-tracker.page.html
+++ b/src/app/essay-tracker/essay-tracker.page.html
@@ -1,4 +1,3 @@
-<ion-page>
   <ion-header>
     <ion-toolbar>
       <ion-title>Essay Tracker</ion-title>
@@ -28,4 +27,3 @@
     <ion-button expand="block" (click)="submit()">Submit</ion-button>
   </div>
   </ion-content>
-</ion-page>

--- a/src/app/essay-tracker/essay-tracker.page.ts
+++ b/src/app/essay-tracker/essay-tracker.page.ts
@@ -15,7 +15,6 @@ import {
   IonSelect,
   IonSelectOption,
 } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { EssayEntry } from '../models/essay-entry';
 
@@ -37,7 +36,6 @@ import { EssayEntry } from '../models/essay-entry';
     IonButton,
     IonSelect,
     IonSelectOption,
-    IonPage,
   ],
   templateUrl: './essay-tracker.page.html',
   styleUrls: ['./essay-tracker.page.scss'],

--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -1,4 +1,3 @@
-<ion-page>
   <ion-header [translucent]="true">
     <ion-toolbar>
       <ion-title>
@@ -27,4 +26,3 @@
       <ion-button routerLink="/leaderboard" expand="block">Leaderboard</ion-button>
     </div>
   </ion-content>
-</ion-page>

--- a/src/app/home/home.page.ts
+++ b/src/app/home/home.page.ts
@@ -1,14 +1,13 @@
 import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import {  IonHeader, IonToolbar, IonTitle, IonContent, IonButton } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-home',
   templateUrl: 'home.page.html',
   styleUrls: ['home.page.scss'],
   standalone: true,
-  imports: [IonHeader, IonToolbar, IonTitle, IonContent, IonButton, RouterLink, IonPage]
+  imports: [IonHeader, IonToolbar, IonTitle, IonContent, IonButton, RouterLink],
 })
 export class HomePage {
   constructor() {}

--- a/src/app/leaderboard/leaderboard.page.html
+++ b/src/app/leaderboard/leaderboard.page.html
@@ -1,4 +1,3 @@
-<ion-page>
   <ion-header>
     <ion-toolbar>
       <ion-title>Leaderboard</ion-title>
@@ -12,4 +11,3 @@
     </ion-item>
   </ion-list>
   </ion-content>
-</ion-page>

--- a/src/app/leaderboard/leaderboard.page.ts
+++ b/src/app/leaderboard/leaderboard.page.ts
@@ -10,7 +10,6 @@ import {
   IonItem,
   IonLabel,
 } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { LeaderboardEntry } from '../models/user-stats';
 
@@ -27,7 +26,6 @@ import { LeaderboardEntry } from '../models/user-stats';
     IonList,
     IonItem,
     IonLabel,
-    IonPage,
   ],
   templateUrl: './leaderboard.page.html',
   styleUrls: ['./leaderboard.page.scss'],

--- a/src/app/login/login.page.html
+++ b/src/app/login/login.page.html
@@ -1,4 +1,3 @@
-<ion-page>
   <ion-header>
     <ion-toolbar>
       <ion-title>Login</ion-title>
@@ -25,4 +24,3 @@
   </ion-list>
   <ion-button expand="block" (click)="login()">Login</ion-button>
   </ion-content>
-</ion-page>

--- a/src/app/login/login.page.ts
+++ b/src/app/login/login.page.ts
@@ -2,7 +2,6 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonSelect, IonSelectOption } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
 import { RoleService } from '../services/role.service';
@@ -25,7 +24,6 @@ import { RoleService } from '../services/role.service';
     IonList,
     IonSelect,
     IonSelectOption,
-    IonPage,
   ],
   templateUrl: './login.page.html',
   styleUrls: ['./login.page.scss'],

--- a/src/app/mental-status/mental-status.page.html
+++ b/src/app/mental-status/mental-status.page.html
@@ -1,4 +1,3 @@
-<ion-page>
   <ion-header>
     <ion-toolbar>
       <ion-title>Mental & Emotional Status</ion-title>
@@ -32,4 +31,3 @@
     <ion-button expand="block" (click)="submit()">Submit</ion-button>
   </div>
   </ion-content>
-</ion-page>

--- a/src/app/mental-status/mental-status.page.ts
+++ b/src/app/mental-status/mental-status.page.ts
@@ -14,7 +14,6 @@ import {
   IonButton,
   IonTextarea,
 } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { MentalStatus } from '../models/mental-status';
 
@@ -35,7 +34,6 @@ import { MentalStatus } from '../models/mental-status';
     IonList,
     IonButton,
     IonTextarea,
-    IonPage,
   ],
   templateUrl: './mental-status.page.html',
   styleUrls: ['./mental-status.page.scss'],

--- a/src/app/project-tracker/project-tracker.page.html
+++ b/src/app/project-tracker/project-tracker.page.html
@@ -1,4 +1,3 @@
-<ion-page>
   <ion-header>
     <ion-toolbar>
       <ion-title>Project Tracker</ion-title>
@@ -36,4 +35,3 @@
     <ion-button expand="block" (click)="submit()">Submit</ion-button>
   </div>
   </ion-content>
-</ion-page>

--- a/src/app/project-tracker/project-tracker.page.ts
+++ b/src/app/project-tracker/project-tracker.page.ts
@@ -15,7 +15,6 @@ import {
   IonSelect,
   IonSelectOption,
 } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { ProjectEntry } from '../models/project-entry';
 
@@ -37,7 +36,6 @@ import { ProjectEntry } from '../models/project-entry';
     IonCheckbox,
     IonSelect,
     IonSelectOption,
-    IonPage,
   ],
   templateUrl: './project-tracker.page.html',
   styleUrls: ['./project-tracker.page.scss'],

--- a/src/app/register/register.page.html
+++ b/src/app/register/register.page.html
@@ -1,4 +1,3 @@
-<ion-page>
   <ion-header>
     <ion-toolbar>
       <ion-title>Register</ion-title>
@@ -18,4 +17,3 @@
   </ion-list>
   <ion-button expand="block" (click)="register()">Register</ion-button>
   </ion-content>
-</ion-page>

--- a/src/app/register/register.page.ts
+++ b/src/app/register/register.page.ts
@@ -2,7 +2,6 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
 
@@ -22,7 +21,6 @@ import { Router } from '@angular/router';
     IonLabel,
     IonButton,
     IonList,
-    IonPage,
   ],
   templateUrl: './register.page.html',
   styleUrls: ['./register.page.scss'],

--- a/src/app/tabs/tabs.page.html
+++ b/src/app/tabs/tabs.page.html
@@ -1,4 +1,3 @@
-<ion-page>
 <ion-tabs>
   <ion-router-outlet></ion-router-outlet>
   <ion-tab-bar slot="bottom">
@@ -36,4 +35,3 @@
     </ng-template>
   </ion-tab-bar>
 </ion-tabs>
-</ion-page>

--- a/src/app/tabs/tabs.page.ts
+++ b/src/app/tabs/tabs.page.ts
@@ -9,7 +9,6 @@ import {
   IonLabel,
   IonRouterOutlet,
 } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular/standalone';
 import { RouterLink, RouterOutlet } from '@angular/router';
 import { RoleService } from '../services/role.service';
 
@@ -26,7 +25,6 @@ import { RoleService } from '../services/role.service';
     IonIcon,
     IonLabel,
     IonRouterOutlet,
-    IonPage,
   ],
   templateUrl: './tabs.page.html',
   styleUrls: ['./tabs.page.scss'],


### PR DESCRIPTION
## Summary
- clean up html templates by dropping `<ion-page>` wrapper
- remove `IonPage` from Angular module imports

## Testing
- `npm test` *(fails: `ng` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685afdfb13bc832794459009b31c82b5