### PR TITLE
Fix unresponsive pages by restoring IonPage wrappers

### DIFF
--- a/src/app/academic-progress/academic-progress.page.html
+++ b/src/app/academic-progress/academic-progress.page.html
@@ -1,3 +1,4 @@
+<ion-page>
   <ion-header>
     <ion-toolbar>
       <ion-title>Academic Progress</ion-title>
@@ -23,3 +24,4 @@
     <ion-button expand="block" (click)="submit()">Submit</ion-button>
   </div>
   </ion-content>
+</ion-page>

--- a/src/app/academic-progress/academic-progress.page.ts
+++ b/src/app/academic-progress/academic-progress.page.ts
@@ -12,6 +12,7 @@ import {
   IonList,
   IonButton,
 } from '@ionic/angular/standalone';
+import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { AcademicProgressEntry } from '../models/academic-progress';
 
@@ -30,6 +31,7 @@ import { AcademicProgressEntry } from '../models/academic-progress';
     IonInput,
     IonList,
     IonButton,
+    IonPage,
   ],
   templateUrl: './academic-progress.page.html',
   styleUrls: ['./academic-progress.page.scss'],

--- a/src/app/bible-quiz/bible-quiz.page.html
+++ b/src/app/bible-quiz/bible-quiz.page.html
@@ -1,3 +1,4 @@
+<ion-page>
   <ion-header>
     <ion-toolbar>
       <ion-title>Bible Quiz</ion-title>
@@ -19,3 +20,4 @@
     <ion-button expand="block" (click)="submit()">Submit</ion-button>
   </div>
   </ion-content>
+</ion-page>

--- a/src/app/bible-quiz/bible-quiz.page.ts
+++ b/src/app/bible-quiz/bible-quiz.page.ts
@@ -12,6 +12,7 @@ import {
   IonList,
   IonButton,
 } from '@ionic/angular/standalone';
+import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { BibleQuestion } from '../models/bible-quiz';
 
@@ -30,6 +31,7 @@ import { BibleQuestion } from '../models/bible-quiz';
     IonInput,
     IonList,
     IonButton,
+    IonPage,
   ],
   templateUrl: './bible-quiz.page.html',
   styleUrls: ['./bible-quiz.page.scss'],

--- a/src/app/check-in/check-in.page.html
+++ b/src/app/check-in/check-in.page.html
@@ -1,3 +1,4 @@
+<ion-page>
   <ion-header>
     <ion-toolbar>
       <ion-title>Daily Check-In</ion-title>
@@ -71,3 +72,4 @@
     <ion-button expand="block" (click)="submit()">Submit</ion-button>
   </div>
   </ion-content>
+</ion-page>

--- a/src/app/check-in/check-in.page.ts
+++ b/src/app/check-in/check-in.page.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import {  IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonTextarea, IonSegment, IonSegmentButton } from '@ionic/angular/standalone';
+import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { DailyCheckin } from '../models/daily-checkin';
 
@@ -23,6 +24,7 @@ import { DailyCheckin } from '../models/daily-checkin';
     IonTextarea,
     IonSegment,
     IonSegmentButton,
+    IonPage,
   ],
   templateUrl: './check-in.page.html',
   styleUrls: ['./check-in.page.scss'],

--- a/src/app/child-account/child-account.page.html
+++ b/src/app/child-account/child-account.page.html
@@ -1,3 +1,4 @@
+<ion-page>
   <ion-header>
     <ion-toolbar>
       <ion-title>Create Child Account</ion-title>
@@ -21,3 +22,4 @@
   </ion-list>
   <ion-button expand="block" (click)="create()">Create</ion-button>
   </ion-content>
+</ion-page>

--- a/src/app/child-account/child-account.page.ts
+++ b/src/app/child-account/child-account.page.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList } from '@ionic/angular/standalone';
+import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
 
@@ -20,6 +21,7 @@ import { Router } from '@angular/router';
     IonLabel,
     IonButton,
     IonList,
+    IonPage,
   ],
   templateUrl: './child-account.page.html',
   styleUrls: ['./child-account.page.scss'],

--- a/src/app/essay-tracker/essay-tracker.page.html
+++ b/src/app/essay-tracker/essay-tracker.page.html
@@ -1,3 +1,4 @@
+<ion-page>
   <ion-header>
     <ion-toolbar>
       <ion-title>Essay Tracker</ion-title>
@@ -27,3 +28,4 @@
     <ion-button expand="block" (click)="submit()">Submit</ion-button>
   </div>
   </ion-content>
+</ion-page>

--- a/src/app/essay-tracker/essay-tracker.page.ts
+++ b/src/app/essay-tracker/essay-tracker.page.ts
@@ -15,6 +15,7 @@ import {
   IonSelect,
   IonSelectOption,
 } from '@ionic/angular/standalone';
+import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { EssayEntry } from '../models/essay-entry';
 
@@ -36,6 +37,7 @@ import { EssayEntry } from '../models/essay-entry';
     IonButton,
     IonSelect,
     IonSelectOption,
+    IonPage,
   ],
   templateUrl: './essay-tracker.page.html',
   styleUrls: ['./essay-tracker.page.scss'],

--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -1,3 +1,4 @@
+<ion-page>
   <ion-header [translucent]="true">
     <ion-toolbar>
       <ion-title>
@@ -26,3 +27,4 @@
       <ion-button routerLink="/leaderboard" expand="block">Leaderboard</ion-button>
     </div>
   </ion-content>
+</ion-page>

--- a/src/app/home/home.page.ts
+++ b/src/app/home/home.page.ts
@@ -1,13 +1,14 @@
 import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import {  IonHeader, IonToolbar, IonTitle, IonContent, IonButton } from '@ionic/angular/standalone';
+import { IonPage } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-home',
   templateUrl: 'home.page.html',
   styleUrls: ['home.page.scss'],
   standalone: true,
-  imports: [IonHeader, IonToolbar, IonTitle, IonContent, IonButton, RouterLink],
+  imports: [IonHeader, IonToolbar, IonTitle, IonContent, IonButton, RouterLink, IonPage]
 })
 export class HomePage {
   constructor() {}

--- a/src/app/leaderboard/leaderboard.page.html
+++ b/src/app/leaderboard/leaderboard.page.html
@@ -1,3 +1,4 @@
+<ion-page>
   <ion-header>
     <ion-toolbar>
       <ion-title>Leaderboard</ion-title>
@@ -11,3 +12,4 @@
     </ion-item>
   </ion-list>
   </ion-content>
+</ion-page>

--- a/src/app/leaderboard/leaderboard.page.ts
+++ b/src/app/leaderboard/leaderboard.page.ts
@@ -10,6 +10,7 @@ import {
   IonItem,
   IonLabel,
 } from '@ionic/angular/standalone';
+import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { LeaderboardEntry } from '../models/user-stats';
 
@@ -26,6 +27,7 @@ import { LeaderboardEntry } from '../models/user-stats';
     IonList,
     IonItem,
     IonLabel,
+    IonPage,
   ],
   templateUrl: './leaderboard.page.html',
   styleUrls: ['./leaderboard.page.scss'],

--- a/src/app/login/login.page.html
+++ b/src/app/login/login.page.html
@@ -1,3 +1,4 @@
+<ion-page>
   <ion-header>
     <ion-toolbar>
       <ion-title>Login</ion-title>
@@ -24,3 +25,4 @@
   </ion-list>
   <ion-button expand="block" (click)="login()">Login</ion-button>
   </ion-content>
+</ion-page>

--- a/src/app/login/login.page.ts
+++ b/src/app/login/login.page.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonSelect, IonSelectOption } from '@ionic/angular/standalone';
+import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
 import { RoleService } from '../services/role.service';
@@ -24,6 +25,7 @@ import { RoleService } from '../services/role.service';
     IonList,
     IonSelect,
     IonSelectOption,
+    IonPage,
   ],
   templateUrl: './login.page.html',
   styleUrls: ['./login.page.scss'],

--- a/src/app/mental-status/mental-status.page.html
+++ b/src/app/mental-status/mental-status.page.html
@@ -1,3 +1,4 @@
+<ion-page>
   <ion-header>
     <ion-toolbar>
       <ion-title>Mental & Emotional Status</ion-title>
@@ -31,3 +32,4 @@
     <ion-button expand="block" (click)="submit()">Submit</ion-button>
   </div>
   </ion-content>
+</ion-page>

--- a/src/app/mental-status/mental-status.page.ts
+++ b/src/app/mental-status/mental-status.page.ts
@@ -14,6 +14,7 @@ import {
   IonButton,
   IonTextarea,
 } from '@ionic/angular/standalone';
+import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { MentalStatus } from '../models/mental-status';
 
@@ -34,6 +35,7 @@ import { MentalStatus } from '../models/mental-status';
     IonList,
     IonButton,
     IonTextarea,
+    IonPage,
   ],
   templateUrl: './mental-status.page.html',
   styleUrls: ['./mental-status.page.scss'],

--- a/src/app/project-tracker/project-tracker.page.html
+++ b/src/app/project-tracker/project-tracker.page.html
@@ -1,3 +1,4 @@
+<ion-page>
   <ion-header>
     <ion-toolbar>
       <ion-title>Project Tracker</ion-title>
@@ -35,3 +36,4 @@
     <ion-button expand="block" (click)="submit()">Submit</ion-button>
   </div>
   </ion-content>
+</ion-page>

--- a/src/app/project-tracker/project-tracker.page.ts
+++ b/src/app/project-tracker/project-tracker.page.ts
@@ -15,6 +15,7 @@ import {
   IonSelect,
   IonSelectOption,
 } from '@ionic/angular/standalone';
+import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { ProjectEntry } from '../models/project-entry';
 
@@ -36,6 +37,7 @@ import { ProjectEntry } from '../models/project-entry';
     IonCheckbox,
     IonSelect,
     IonSelectOption,
+    IonPage,
   ],
   templateUrl: './project-tracker.page.html',
   styleUrls: ['./project-tracker.page.scss'],

--- a/src/app/register/register.page.html
+++ b/src/app/register/register.page.html
@@ -1,3 +1,4 @@
+<ion-page>
   <ion-header>
     <ion-toolbar>
       <ion-title>Register</ion-title>
@@ -17,3 +18,4 @@
   </ion-list>
   <ion-button expand="block" (click)="register()">Register</ion-button>
   </ion-content>
+</ion-page>

--- a/src/app/register/register.page.ts
+++ b/src/app/register/register.page.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList } from '@ionic/angular/standalone';
+import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
 
@@ -21,6 +22,7 @@ import { Router } from '@angular/router';
     IonLabel,
     IonButton,
     IonList,
+    IonPage,
   ],
   templateUrl: './register.page.html',
   styleUrls: ['./register.page.scss'],

--- a/src/app/tabs/tabs.page.html
+++ b/src/app/tabs/tabs.page.html
@@ -1,3 +1,4 @@
+<ion-page>
 <ion-tabs>
   <ion-router-outlet></ion-router-outlet>
   <ion-tab-bar slot="bottom">
@@ -35,3 +36,4 @@
     </ng-template>
   </ion-tab-bar>
 </ion-tabs>
+</ion-page>

--- a/src/app/tabs/tabs.page.ts
+++ b/src/app/tabs/tabs.page.ts
@@ -9,6 +9,7 @@ import {
   IonLabel,
   IonRouterOutlet,
 } from '@ionic/angular/standalone';
+import { IonPage } from '@ionic/angular/standalone';
 import { RouterLink, RouterOutlet } from '@angular/router';
 import { RoleService } from '../services/role.service';
 
@@ -25,6 +26,7 @@ import { RoleService } from '../services/role.service';
     IonIcon,
     IonLabel,
     IonRouterOutlet,
+    IonPage,
   ],
   templateUrl: './tabs.page.html',
   styleUrls: ['./tabs.page.scss'],


### PR DESCRIPTION
## Summary
- restore `<ion-page>` wrappers and IonPage imports for all pages

## Testing
- `npm test` *(fails: ng not found)*
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b21d5a5b08327b8d1af7b0c5dac3a