### PR TITLE
Add login redirect and registration links

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,7 @@
 import { Component } from '@angular/core';
 import { IonApp, IonRouterOutlet } from '@ionic/angular/standalone';
+import { Router } from '@angular/router';
+import { FirebaseService } from './services/firebase.service';
 
 @Component({
   selector: 'app-root',
@@ -7,5 +9,16 @@ import { IonApp, IonRouterOutlet } from '@ionic/angular/standalone';
   imports: [IonApp, IonRouterOutlet],
 })
 export class AppComponent {
-  constructor() {}
+  constructor(private router: Router, private fb: FirebaseService) {
+    this.fb.auth.onAuthStateChanged((user) => {
+      const url = this.router.url;
+      if (!user) {
+        if (!url.startsWith('/login') && !url.startsWith('/register')) {
+          this.router.navigateByUrl('/login');
+        }
+      } else if (url === '/login' || url === '/register' || url === '/') {
+        this.router.navigateByUrl('/tabs');
+      }
+    });
+  }
 }

--- a/src/app/login/login.page.html
+++ b/src/app/login/login.page.html
@@ -24,5 +24,8 @@
     </ion-item>
   </ion-list>
   <ion-button expand="block" (click)="login()">Login</ion-button>
+  <ion-button routerLink="/register" fill="clear" expand="block">
+    Don't have an account? Register
+  </ion-button>
   </ion-content>
 

--- a/src/app/login/login.page.ts
+++ b/src/app/login/login.page.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonSelect, IonSelectOption } from '@ionic/angular/standalone';
+import { RouterLink } from '@angular/router';
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
 import { RoleService } from '../services/role.service';
@@ -24,6 +25,7 @@ import { RoleService } from '../services/role.service';
     IonList,
     IonSelect,
     IonSelectOption,
+    RouterLink,
   ],
   templateUrl: './login.page.html',
   styleUrls: ['./login.page.scss'],

--- a/src/app/register/register.page.html
+++ b/src/app/register/register.page.html
@@ -17,5 +17,8 @@
     </ion-item>
   </ion-list>
   <ion-button expand="block" (click)="register()">Register</ion-button>
+  <ion-button routerLink="/login" fill="clear" expand="block">
+    Already have an account? Login
+  </ion-button>
   </ion-content>
 

--- a/src/app/register/register.page.ts
+++ b/src/app/register/register.page.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList } from '@ionic/angular/standalone';
+import { RouterLink } from '@angular/router';
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
 
@@ -21,6 +22,7 @@ import { Router } from '@angular/router';
     IonLabel,
     IonButton,
     IonList,
+    RouterLink,
   ],
   templateUrl: './register.page.html',
   styleUrls: ['./register.page.scss'],


### PR DESCRIPTION
## Summary
- show login page when no user is authenticated
- add link from login to register page
- add link from register to login page

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b3d787e6083278c33c7ae42135440