### PR TITLE
Add help request field to daily check-in

### DIFF
--- a/src/app/check-in/check-in.page.html
+++ b/src/app/check-in/check-in.page.html
@@ -67,6 +67,10 @@
       <ion-label>Need Help?</ion-label>
       <ion-checkbox slot="start" [(ngModel)]="form.needsHelp"></ion-checkbox>
     </ion-item>
+    <ion-item *ngIf="form.needsHelp">
+      <ion-label position="stacked">How can we help?</ion-label>
+      <ion-textarea [(ngModel)]="form.helpRequest"></ion-textarea>
+    </ion-item>
   </ion-list>
   <div class="ion-padding">
     <ion-button expand="block" (click)="submit()">Submit</ion-button>

--- a/src/app/check-in/check-in.page.ts
+++ b/src/app/check-in/check-in.page.ts
@@ -41,6 +41,7 @@ export class CheckInPage {
     appetite: '',
     treatment: '',
     needsHelp: false,
+    helpRequest: '',
   };
 
   constructor(private fbService: FirebaseService) {}

--- a/src/app/models/daily-checkin.ts
+++ b/src/app/models/daily-checkin.ts
@@ -10,6 +10,7 @@ export interface DailyCheckin {
   appetite: string;
   treatment: string;
   needsHelp: boolean;
+  helpRequest: string;
   userId?: string | null;
   parentId?: string | null;
   date: string;


### PR DESCRIPTION
## Summary
- extend `DailyCheckin` model to store a help request
- show a textarea when "Need Help?" is checked
- track the help request value in the form

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b521ccdf8832798d7e99942eb978c