### PR TITLE
Implement role assignment with admin privileges

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { IonApp, IonRouterOutlet } from '@ionic/angular/standalone';
 import { Router } from '@angular/router';
 import { FirebaseService } from './services/firebase.service';
+import { RoleService } from './services/role.service';
 
 @Component({
   selector: 'app-root',
@@ -9,15 +10,24 @@ import { FirebaseService } from './services/firebase.service';
   imports: [IonApp, IonRouterOutlet],
 })
 export class AppComponent {
-  constructor(private router: Router, private fb: FirebaseService) {
-    this.fb.auth.onAuthStateChanged((user) => {
+  constructor(
+    private router: Router,
+    private fb: FirebaseService,
+    private roleSvc: RoleService
+  ) {
+    this.fb.auth.onAuthStateChanged(async (user) => {
       const url = this.router.url;
       if (!user) {
         if (!url.startsWith('/login') && !url.startsWith('/register')) {
           this.router.navigateByUrl('/login');
         }
-      } else if (url === '/login' || url === '/register' || url === '/') {
-        this.router.navigateByUrl('/tabs');
+        this.roleSvc.setRole(null);
+      } else {
+        const role = await this.fb.getUserRole(user.uid);
+        this.roleSvc.setRole(role);
+        if (url === '/login' || url === '/register' || url === '/') {
+          this.router.navigateByUrl('/tabs');
+        }
       }
     });
   }

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -53,6 +53,11 @@ export const routes: Routes = [
           import('./leaderboard/leaderboard.page').then((m) => m.LeaderboardPage),
       },
       {
+        path: 'manage-roles',
+        loadComponent: () =>
+          import('./manage-roles/manage-roles.page').then((m) => m.ManageRolesPage),
+      },
+      {
         path: '',
         redirectTo: 'home',
         pathMatch: 'full',

--- a/src/app/child-account/child-account.page.ts
+++ b/src/app/child-account/child-account.page.ts
@@ -37,12 +37,13 @@ export class ChildAccountPage {
     if (this.form.age === null) {
       return;
     }
-    await this.fb.createChildAccount(
+    const cred = await this.fb.createChildAccount(
       this.form.email,
       this.form.password,
       user.uid,
       this.form.age
     );
+    await this.fb.saveUser(cred.user.uid, this.form.email, 'child');
     this.router.navigateByUrl('/home');
   }
 }

--- a/src/app/login/login.page.html
+++ b/src/app/login/login.page.html
@@ -15,13 +15,6 @@
       <ion-label position="stacked">Password</ion-label>
       <ion-input type="password" [(ngModel)]="form.password"></ion-input>
     </ion-item>
-    <ion-item>
-      <ion-label position="stacked">Role</ion-label>
-      <ion-select [(ngModel)]="selectedRole">
-        <ion-select-option value="parent">Parent</ion-select-option>
-        <ion-select-option value="child">Child</ion-select-option>
-      </ion-select>
-    </ion-item>
   </ion-list>
   <ion-button expand="block" (click)="login()">Login</ion-button>
   <ion-button routerLink="/register" fill="clear" expand="block">

--- a/src/app/login/login.page.ts
+++ b/src/app/login/login.page.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonSelect, IonSelectOption } from '@ionic/angular/standalone';
+import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList } from '@ionic/angular/standalone';
 import { RouterLink } from '@angular/router';
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
@@ -23,8 +23,6 @@ import { RoleService } from '../services/role.service';
     IonLabel,
     IonButton,
     IonList,
-    IonSelect,
-    IonSelectOption,
     RouterLink,
   ],
   templateUrl: './login.page.html',
@@ -32,7 +30,6 @@ import { RoleService } from '../services/role.service';
 })
 export class LoginPage {
   form = { email: '', password: '' };
-  selectedRole = 'parent';
 
   constructor(
     private fb: FirebaseService,
@@ -41,8 +38,9 @@ export class LoginPage {
   ) {}
 
   async login() {
-    await this.fb.login(this.form.email, this.form.password);
-    this.roleSvc.setRole(this.selectedRole);
+    const cred = await this.fb.login(this.form.email, this.form.password);
+    const role = await this.fb.getUserRole(cred.user.uid);
+    this.roleSvc.setRole(role);
     this.router.navigateByUrl('/tabs');
   }
 }

--- a/src/app/manage-roles/manage-roles.page.html
+++ b/src/app/manage-roles/manage-roles.page.html
@@ -1,0 +1,18 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Manage Roles</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content class="ion-padding">
+  <ion-list>
+    <ion-item *ngFor="let user of users">
+      <ion-label>{{ user.email }}</ion-label>
+      <ion-select [(ngModel)]="user.role" (ionChange)="updateRole(user)">
+        <ion-select-option value="parent">Parent</ion-select-option>
+        <ion-select-option value="child">Child</ion-select-option>
+        <ion-select-option value="admin">Admin</ion-select-option>
+      </ion-select>
+    </ion-item>
+  </ion-list>
+</ion-content>

--- a/src/app/manage-roles/manage-roles.page.ts
+++ b/src/app/manage-roles/manage-roles.page.ts
@@ -1,0 +1,54 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import {
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonContent,
+  IonList,
+  IonItem,
+  IonLabel,
+  IonSelect,
+  IonSelectOption,
+} from '@ionic/angular/standalone';
+import { FirebaseService } from '../services/firebase.service';
+
+interface UserRecord {
+  id: string;
+  email: string;
+  role: string;
+}
+
+@Component({
+  selector: 'app-manage-roles',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
+    IonContent,
+    IonList,
+    IonItem,
+    IonLabel,
+    IonSelect,
+    IonSelectOption,
+  ],
+  templateUrl: './manage-roles.page.html',
+  styleUrls: ['./manage-roles.page.scss'],
+})
+export class ManageRolesPage implements OnInit {
+  users: UserRecord[] = [];
+
+  constructor(private fb: FirebaseService) {}
+
+  async ngOnInit() {
+    this.users = await this.fb.getAllUsers();
+  }
+
+  async updateRole(user: UserRecord) {
+    await this.fb.setUserRole(user.id, user.role);
+  }
+}

--- a/src/app/register/register.page.ts
+++ b/src/app/register/register.page.ts
@@ -33,7 +33,8 @@ export class RegisterPage {
   constructor(private fb: FirebaseService, private router: Router) {}
 
   async register() {
-    await this.fb.register(this.form.email, this.form.password);
+    const cred = await this.fb.register(this.form.email, this.form.password);
+    await this.fb.saveUser(cred.user.uid, this.form.email, 'parent');
     this.router.navigateByUrl('/login');
   }
 }

--- a/src/app/services/firebase.service.ts
+++ b/src/app/services/firebase.service.ts
@@ -40,6 +40,27 @@ export class FirebaseService {
     return signInWithEmailAndPassword(this.auth, email, password);
   }
 
+  saveUser(uid: string, email: string, role: string) {
+    return setDoc(doc(this.db, 'users', uid), { email, role }, { merge: true });
+  }
+
+  async getUserRole(uid: string): Promise<string | null> {
+    const snap = await getDoc(doc(this.db, 'users', uid));
+    if (!snap.exists()) {
+      return null;
+    }
+    return (snap.data() as { role?: string }).role || null;
+  }
+
+  setUserRole(uid: string, role: string) {
+    return setDoc(doc(this.db, 'users', uid), { role }, { merge: true });
+  }
+
+  async getAllUsers(): Promise<{ id: string; email: string; role: string }[]> {
+    const snap = await getDocs(collection(this.db, 'users'));
+    return snap.docs.map((d) => ({ id: d.id, ...(d.data() as any) }));
+  }
+
   async createChildAccount(
     email: string,
     password: string,

--- a/src/app/tabs/tabs.page.html
+++ b/src/app/tabs/tabs.page.html
@@ -1,7 +1,7 @@
 <ion-tabs>
 
   <ion-tab-bar slot="bottom">
-    <ng-container *ngIf="role === 'parent'; else childTabs">
+    <ng-container *ngIf="role === 'parent' || role === 'admin'; else childTabs">
       <ion-tab-button tab="home" href="/tabs/home">
         <ion-icon name="home-outline"></ion-icon>
         <ion-label>Home</ion-label>
@@ -13,6 +13,14 @@
       <ion-tab-button tab="leaderboard" href="/tabs/leaderboard">
         <ion-icon name="trophy-outline"></ion-icon>
         <ion-label>Scores</ion-label>
+      </ion-tab-button>
+      <ion-tab-button
+        tab="manage-roles"
+        href="/tabs/manage-roles"
+        *ngIf="role === 'admin'"
+      >
+        <ion-icon name="shield-checkmark-outline"></ion-icon>
+        <ion-label>Roles</ion-label>
       </ion-tab-button>
     </ng-container>
     <ng-template #childTabs>


### PR DESCRIPTION
## Summary
- persist user roles in Firestore via FirebaseService
- set default role on registration and child account creation
- load user role on login and auth state change
- add admin-only manage roles page to change roles
- expose manage-roles tab when logged in as admin

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b7d99d5f48327b7f702f9a479149d