### PR TITLE
Add logout support

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,3 +1,13 @@
 <ion-app>
+  <ion-header *ngIf="loggedIn">
+    <ion-toolbar>
+      <ion-title>Kids Faith Tracker</ion-title>
+      <ion-buttons slot="end">
+        <ion-button (click)="logout()">
+          <ion-icon name="log-out-outline"></ion-icon>
+        </ion-button>
+      </ion-buttons>
+    </ion-toolbar>
+  </ion-header>
   <ion-router-outlet></ion-router-outlet>
 </ion-app>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,16 +1,37 @@
 import { Component } from '@angular/core';
-import { IonApp, IonRouterOutlet } from '@ionic/angular/standalone';
+import {
+  IonApp,
+  IonRouterOutlet,
+  IonHeader,
+  IonToolbar,
+  IonButtons,
+  IonButton,
+  IonIcon,
+  IonTitle,
+} from '@ionic/angular/standalone';
 import { Router } from '@angular/router';
 import { FirebaseService } from './services/firebase.service';
 
 @Component({
   selector: 'app-root',
   templateUrl: 'app.component.html',
-  imports: [IonApp, IonRouterOutlet],
+  imports: [
+    IonApp,
+    IonRouterOutlet,
+    IonHeader,
+    IonToolbar,
+    IonButtons,
+    IonButton,
+    IonIcon,
+    IonTitle,
+  ],
 })
 export class AppComponent {
+  loggedIn = false;
+
   constructor(private router: Router, private fb: FirebaseService) {
     this.fb.auth.onAuthStateChanged((user) => {
+      this.loggedIn = !!user;
       const url = this.router.url;
       if (!user) {
         if (!url.startsWith('/login') && !url.startsWith('/register')) {
@@ -20,5 +41,9 @@ export class AppComponent {
         this.router.navigateByUrl('/tabs');
       }
     });
+  }
+
+  logout() {
+    this.fb.logout();
   }
 }

--- a/src/app/services/firebase.service.ts
+++ b/src/app/services/firebase.service.ts
@@ -1,6 +1,13 @@
 import { Injectable } from '@angular/core';
 import { initializeApp } from 'firebase/app';
-import { getAuth, createUserWithEmailAndPassword, signInWithEmailAndPassword, Auth, UserCredential } from 'firebase/auth';
+import {
+  getAuth,
+  createUserWithEmailAndPassword,
+  signInWithEmailAndPassword,
+  signOut,
+  Auth,
+  UserCredential,
+} from 'firebase/auth';
 import {
   getFirestore,
   collection,
@@ -38,6 +45,10 @@ export class FirebaseService {
 
   login(email: string, password: string): Promise<UserCredential> {
     return signInWithEmailAndPassword(this.auth, email, password);
+  }
+
+  logout(): Promise<void> {
+    return signOut(this.auth);
   }
 
   async createChildAccount(


### PR DESCRIPTION
## Summary
- allow signing out via Firebase service
- show logout icon in a persistent header

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b8e9cd4d48327b48319374d2c58be