### PR TITLE
Implement role-based home tiles

### DIFF
--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -14,17 +14,59 @@
       </ion-toolbar>
     </ion-header>
 
-    <div class="ion-padding">
-      <ion-button routerLink="/check-in" expand="block">Daily Check-In</ion-button>
-      <ion-button routerLink="/login" expand="block">Login</ion-button>
-      <ion-button routerLink="/register" expand="block">Register</ion-button>
-      <ion-button routerLink="/child-account" expand="block">Create Child</ion-button>
-      <ion-button routerLink="/mental-status" expand="block">Mental Status</ion-button>
-      <ion-button routerLink="/bible-quiz" expand="block">Bible Quiz</ion-button>
-      <ion-button routerLink="/essay-tracker" expand="block">Essay Tracker</ion-button>
-      <ion-button routerLink="/academic-progress" expand="block">Academic Progress</ion-button>
-      <ion-button routerLink="/project-tracker" expand="block">Project Tracker</ion-button>
-      <ion-button routerLink="/leaderboard" expand="block">Leaderboard</ion-button>
-    </div>
+    <ion-grid>
+      <!-- Unauthenticated -->
+      <ion-row *ngIf="!role">
+        <ion-col size="6">
+          <ion-button routerLink="/login" expand="block">Login</ion-button>
+        </ion-col>
+        <ion-col size="6">
+          <ion-button routerLink="/register" expand="block">Register</ion-button>
+        </ion-col>
+      </ion-row>
+
+      <!-- Parent Buttons -->
+      <ion-row *ngIf="role === 'parent'">
+        <ion-col size="6">
+          <ion-button routerLink="/child-account" expand="block">Create Child</ion-button>
+        </ion-col>
+        <ion-col size="6">
+          <ion-button routerLink="/leaderboard" expand="block">Leaderboard</ion-button>
+        </ion-col>
+      </ion-row>
+
+      <!-- Child Buttons -->
+      <ng-container *ngIf="role === 'child'">
+        <ion-row>
+          <ion-col size="6">
+            <ion-button routerLink="/check-in" expand="block">Daily Check-In</ion-button>
+          </ion-col>
+          <ion-col size="6">
+            <ion-button routerLink="/mental-status" expand="block">Mental Status</ion-button>
+          </ion-col>
+        </ion-row>
+        <ion-row>
+          <ion-col size="6">
+            <ion-button routerLink="/bible-quiz" expand="block">Bible Quiz</ion-button>
+          </ion-col>
+          <ion-col size="6">
+            <ion-button routerLink="/essay-tracker" expand="block">Essay Tracker</ion-button>
+          </ion-col>
+        </ion-row>
+        <ion-row>
+          <ion-col size="6">
+            <ion-button routerLink="/academic-progress" expand="block">Academic Progress</ion-button>
+          </ion-col>
+          <ion-col size="6">
+            <ion-button routerLink="/project-tracker" expand="block">Project Tracker</ion-button>
+          </ion-col>
+        </ion-row>
+        <ion-row>
+          <ion-col size="6">
+            <ion-button routerLink="/leaderboard" expand="block">Leaderboard</ion-button>
+          </ion-col>
+        </ion-row>
+      </ng-container>
+    </ion-grid>
   </ion-content>
 

--- a/src/app/home/home.page.ts
+++ b/src/app/home/home.page.ts
@@ -1,14 +1,38 @@
 import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import {  IonHeader, IonToolbar, IonTitle, IonContent, IonButton } from '@ionic/angular/standalone';
+import {
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonContent,
+  IonButton,
+  IonGrid,
+  IonRow,
+  IonCol,
+} from '@ionic/angular/standalone';
+import { RoleService } from '../services/role.service';
 
 @Component({
   selector: 'app-home',
   templateUrl: 'home.page.html',
   styleUrls: ['home.page.scss'],
   standalone: true,
-  imports: [ IonHeader, IonToolbar, IonTitle, IonContent, IonButton, RouterLink]
+  imports: [
+    IonHeader,
+    IonToolbar,
+    IonTitle,
+    IonContent,
+    IonButton,
+    IonGrid,
+    IonRow,
+    IonCol,
+    RouterLink,
+  ],
 })
 export class HomePage {
-  constructor() {}
+  constructor(public roleSvc: RoleService) {}
+
+  get role(): string | null {
+    return this.roleSvc.role;
+  }
 }


### PR DESCRIPTION
## Summary
- add role service to home page
- show 2-column grid of buttons depending on role

## Testing
- `npm test --silent -- --no-watch --no-progress` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b90bf1414832788f59699ac75fff5