### PR TITLE
Add persistent home and logout navigation

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,6 +1,11 @@
 <ion-app>
   <ion-header *ngIf="loggedIn">
     <ion-toolbar>
+      <ion-buttons slot="start">
+        <ion-button routerLink="/tabs">
+          <ion-icon name="home-outline"></ion-icon>
+        </ion-button>
+      </ion-buttons>
       <ion-title>Kids Faith Tracker</ion-title>
       <ion-buttons slot="end">
         <ion-button (click)="logout()">

--- a/src/app/tabs/tabs.page.html
+++ b/src/app/tabs/tabs.page.html
@@ -33,6 +33,9 @@
         <ion-label>Projects</ion-label>
       </ion-tab-button>
     </ng-template>
+    <ion-tab-button tab="logout" (click)="logout(); $event.preventDefault()">
+      <ion-icon name="log-out-outline"></ion-icon>
+    </ion-tab-button>
   </ion-tab-bar>
 
 </ion-tabs>

--- a/src/app/tabs/tabs.page.ts
+++ b/src/app/tabs/tabs.page.ts
@@ -11,6 +11,7 @@ import {
 } from '@ionic/angular/standalone';
 import { RouterLink, RouterOutlet } from '@angular/router';
 import { RoleService } from '../services/role.service';
+import { FirebaseService } from '../services/firebase.service';
 
 @Component({
   selector: 'app-tabs',
@@ -28,7 +29,11 @@ import { RoleService } from '../services/role.service';
   styleUrls: ['./tabs.page.scss'],
 })
 export class TabsPage {
-  constructor(public roleSvc: RoleService) {}
+  constructor(public roleSvc: RoleService, private fb: FirebaseService) {}
+
+  logout() {
+    this.fb.logout();
+  }
 
   get role(): string | null {
     return this.roleSvc.role;


### PR DESCRIPTION
## Summary
- show a home icon in the main toolbar for quick navigation back to Home
- add a logout button to the tab bar so logout is always available

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_685c203939348327b8ab45d8646e9bc9