### PR TITLE
Fix logout icon and session reset

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -11,6 +11,7 @@ import {
 } from '@ionic/angular/standalone';
 import { Router } from '@angular/router';
 import { FirebaseService } from './services/firebase.service';
+import { RoleService } from './services/role.service';
 import { NgIf } from '@angular/common';
 
 @Component({
@@ -31,7 +32,7 @@ import { NgIf } from '@angular/common';
 export class AppComponent {
   loggedIn = false;
 
-  constructor(private router: Router, private fb: FirebaseService) {
+  constructor(private router: Router, private fb: FirebaseService, private roleSvc: RoleService) {
     this.fb.auth.onAuthStateChanged((user) => {
       this.loggedIn = !!user;
       const url = this.router.url;
@@ -46,6 +47,7 @@ export class AppComponent {
   }
 
   logout() {
+    this.roleSvc.setRole(null);
     this.fb.logout();
   }
 }

--- a/src/app/tabs/tabs.page.ts
+++ b/src/app/tabs/tabs.page.ts
@@ -32,6 +32,7 @@ export class TabsPage {
   constructor(public roleSvc: RoleService, private fb: FirebaseService) {}
 
   logout() {
+    this.roleSvc.setRole(null);
     this.fb.logout();
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,10 @@ import {
   helpOutline,
   createOutline,
   listOutline,
+  homeOutline,
+  logOutOutline,
+  personAddOutline,
+  trophyOutline,
 } from 'ionicons/icons';
 
 import { routes } from './app/app.routes';
@@ -25,6 +29,10 @@ addIcons({
   helpOutline,
   createOutline,
   listOutline,
+  homeOutline,
+  logOutOutline,
+  personAddOutline,
+  trophyOutline,
 });
 
 bootstrapApplication(AppComponent, {


### PR DESCRIPTION
## Summary
- register logout and navigation icons in `addIcons`
- reset user role when logging out

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c21f3de288327a8e3d868995c8d73