### PR TITLE
Fix tabs visibility across navigation

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -50,7 +50,14 @@ export const routes: Routes = [
       {
         path: 'leaderboard',
         loadComponent: () =>
-          import('./leaderboard/leaderboard.page').then((m) => m.LeaderboardPage),
+      import('./leaderboard/leaderboard.page').then((m) => m.LeaderboardPage),
+      },
+      {
+        path: 'mental-status',
+        loadComponent: () =>
+          import('./mental-status/mental-status.page').then(
+            (m) => m.MentalStatusPage
+          ),
       },
       {
         path: '',
@@ -67,11 +74,6 @@ export const routes: Routes = [
     path: 'register',
     loadComponent: () =>
       import('./register/register.page').then((m) => m.RegisterPage),
-  },
-  {
-    path: 'mental-status',
-    loadComponent: () =>
-      import('./mental-status/mental-status.page').then((m) => m.MentalStatusPage),
   },
   {
     path: '',

--- a/src/app/child-account/child-account.page.ts
+++ b/src/app/child-account/child-account.page.ts
@@ -43,6 +43,6 @@ export class ChildAccountPage {
       user.uid,
       this.form.age
     );
-    this.router.navigateByUrl('/home');
+    this.router.navigateByUrl('/tabs/home');
   }
 }

--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -27,10 +27,10 @@
       <!-- Parent Buttons -->
       <ion-row *ngIf="role === 'parent'">
         <ion-col size="6">
-          <ion-button class="tile-button" routerLink="/child-account" expand="block">Create Child</ion-button>
+          <ion-button class="tile-button" routerLink="/tabs/child-account" expand="block">Create Child</ion-button>
         </ion-col>
         <ion-col size="6">
-          <ion-button class="tile-button" routerLink="/leaderboard" expand="block">Leaderboard</ion-button>
+          <ion-button class="tile-button" routerLink="/tabs/leaderboard" expand="block">Leaderboard</ion-button>
         </ion-col>
       </ion-row>
 
@@ -38,31 +38,31 @@
       <ng-container *ngIf="role === 'child'">
         <ion-row>
           <ion-col size="6">
-            <ion-button class="tile-button" routerLink="/check-in" expand="block">Daily Check-In</ion-button>
+          <ion-button class="tile-button" routerLink="/tabs/check-in" expand="block">Daily Check-In</ion-button>
           </ion-col>
           <ion-col size="6">
-            <ion-button class="tile-button" routerLink="/mental-status" expand="block">Mental Status</ion-button>
-          </ion-col>
-        </ion-row>
-        <ion-row>
-          <ion-col size="6">
-            <ion-button class="tile-button" routerLink="/bible-quiz" expand="block">Bible Quiz</ion-button>
-          </ion-col>
-          <ion-col size="6">
-            <ion-button class="tile-button" routerLink="/essay-tracker" expand="block">Essay Tracker</ion-button>
+          <ion-button class="tile-button" routerLink="/tabs/mental-status" expand="block">Mental Status</ion-button>
           </ion-col>
         </ion-row>
         <ion-row>
           <ion-col size="6">
-            <ion-button class="tile-button" routerLink="/academic-progress" expand="block">Academic Progress</ion-button>
+          <ion-button class="tile-button" routerLink="/tabs/bible-quiz" expand="block">Bible Quiz</ion-button>
           </ion-col>
           <ion-col size="6">
-            <ion-button class="tile-button" routerLink="/project-tracker" expand="block">Project Tracker</ion-button>
+          <ion-button class="tile-button" routerLink="/tabs/essay-tracker" expand="block">Essay Tracker</ion-button>
           </ion-col>
         </ion-row>
         <ion-row>
           <ion-col size="6">
-            <ion-button class="tile-button" routerLink="/leaderboard" expand="block">Leaderboard</ion-button>
+          <ion-button class="tile-button" routerLink="/tabs/academic-progress" expand="block">Academic Progress</ion-button>
+          </ion-col>
+          <ion-col size="6">
+          <ion-button class="tile-button" routerLink="/tabs/project-tracker" expand="block">Project Tracker</ion-button>
+          </ion-col>
+        </ion-row>
+        <ion-row>
+          <ion-col size="6">
+          <ion-button class="tile-button" routerLink="/tabs/leaderboard" expand="block">Leaderboard</ion-button>
           </ion-col>
         </ion-row>
       </ng-container>


### PR DESCRIPTION
## Summary
- keep bottom tabs visible when navigating from Home
- update child creation success navigation
- move mental status page under `tabs`

## Testing
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c2ad37a208327a233cf097e7ca813