### PR TITLE
Fix essay tracker form control

### DIFF
--- a/src/app/essay-tracker/essay-tracker.page.ts
+++ b/src/app/essay-tracker/essay-tracker.page.ts
@@ -14,6 +14,7 @@ import {
   IonButton,
   IonSelect,
   IonSelectOption,
+  IonCheckbox,
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { EssayEntry } from '../models/essay-entry';
@@ -36,6 +37,7 @@ import { EssayEntry } from '../models/essay-entry';
     IonButton,
     IonSelect,
     IonSelectOption,
+    IonCheckbox,
   ],
   templateUrl: './essay-tracker.page.html',
   styleUrls: ['./essay-tracker.page.scss'],


### PR DESCRIPTION
## Summary
- import `IonCheckbox` in the Essay Tracker page

## Testing
- `npx ng test --watch=false` *(fails: E403 Forbidden)*
- `npx ng lint` *(fails: E403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685c2e9ec39c8327bfef10325b399240