### PR TITLE
Fix logout tab route

### DIFF
--- a/src/app/tabs/tabs.page.html
+++ b/src/app/tabs/tabs.page.html
@@ -33,9 +33,9 @@
         <ion-label>Projects</ion-label>
       </ion-tab-button>
     </ng-template>
-    <ion-tab-button tab="logout" (click)="logout(); $event.preventDefault()">
-      <ion-icon name="log-out-outline"></ion-icon>
-    </ion-tab-button>
+      <ion-tab-button tab="logout" href="/login" (click)="logout()">
+        <ion-icon name="log-out-outline"></ion-icon>
+      </ion-tab-button>
   </ion-tab-bar>
 
 </ion-tabs>


### PR DESCRIPTION
## Summary
- navigate to login when tapping logout tab

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c315b8a608327b07209b3bd56c396