### PR TITLE
Force child login role

### DIFF
--- a/src/app/login/login.page.html
+++ b/src/app/login/login.page.html
@@ -15,13 +15,6 @@
       <ion-label position="stacked">Password</ion-label>
       <ion-input type="password" [(ngModel)]="form.password"></ion-input>
     </ion-item>
-    <ion-item>
-      <ion-label position="stacked">Role</ion-label>
-      <ion-select [(ngModel)]="selectedRole">
-        <ion-select-option value="parent">Parent</ion-select-option>
-        <ion-select-option value="child">Child</ion-select-option>
-      </ion-select>
-    </ion-item>
   </ion-list>
   <ion-button expand="block" (click)="login()">Login</ion-button>
   <ion-button routerLink="/register" fill="clear" expand="block">

--- a/src/app/login/login.page.ts
+++ b/src/app/login/login.page.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonSelect, IonSelectOption } from '@ionic/angular/standalone';
+import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList } from '@ionic/angular/standalone';
 import { RouterLink } from '@angular/router';
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
@@ -11,7 +11,7 @@ import { RoleService } from '../services/role.service';
   selector: 'app-login',
   standalone: true,
   imports: [
-   
+
     CommonModule,
     FormsModule,
     IonHeader,
@@ -23,8 +23,6 @@ import { RoleService } from '../services/role.service';
     IonLabel,
     IonButton,
     IonList,
-    IonSelect,
-    IonSelectOption,
     RouterLink,
   ],
   templateUrl: './login.page.html',
@@ -32,7 +30,6 @@ import { RoleService } from '../services/role.service';
 })
 export class LoginPage {
   form = { email: '', password: '' };
-  selectedRole = 'parent';
 
   constructor(
     private fb: FirebaseService,
@@ -41,8 +38,9 @@ export class LoginPage {
   ) {}
 
   async login() {
-    await this.fb.login(this.form.email, this.form.password);
-    this.roleSvc.setRole(this.selectedRole);
+    const cred = await this.fb.login(this.form.email, this.form.password);
+    const isChild = await this.fb.isChildAccount(cred.user.uid);
+    this.roleSvc.setRole(isChild ? 'child' : 'parent');
     this.router.navigateByUrl('/tabs');
   }
 }

--- a/src/app/services/firebase.service.ts
+++ b/src/app/services/firebase.service.ts
@@ -51,6 +51,12 @@ export class FirebaseService {
     return signOut(this.auth);
   }
 
+  async isChildAccount(userId: string): Promise<boolean> {
+    const ref = doc(this.db, 'childProfiles', userId);
+    const snap = await getDoc(ref);
+    return snap.exists();
+  }
+
   async createChildAccount(
     email: string,
     password: string,


### PR DESCRIPTION
## Summary
- detect if user has a child profile
- set role based on account type on login
- remove role selector from login page

## Testing
- `npm test` *(fails: `ng` not found)*
- `npx ng test` *(fails: cannot reach npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_685c3332c4988327846b9c30ad2c5a13