### PR TITLE
Implement Bible quiz API integration

### DIFF
--- a/src/app/bible-quiz/bible-quiz.page.html
+++ b/src/app/bible-quiz/bible-quiz.page.html
@@ -11,7 +11,13 @@
       <ion-label position="stacked">Question</ion-label>
       <ion-label>{{ question.text }}</ion-label>
     </ion-item>
-    <ion-item>
+    <ion-radio-group [(ngModel)]="answer" *ngIf="question.options?.length">
+      <ion-item *ngFor="let opt of question.options">
+        <ion-label>{{ opt }}</ion-label>
+        <ion-radio slot="end" [value]="opt"></ion-radio>
+      </ion-item>
+    </ion-radio-group>
+    <ion-item *ngIf="!question.options?.length">
       <ion-label position="stacked">Your Answer</ion-label>
       <ion-input [(ngModel)]="answer"></ion-input>
     </ion-item>

--- a/src/app/bible-quiz/bible-quiz.page.spec.ts
+++ b/src/app/bible-quiz/bible-quiz.page.spec.ts
@@ -1,8 +1,21 @@
 import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 import { BibleQuizPage } from './bible-quiz.page';
+import { BibleQuizApiService } from '../services/bible-quiz-api.service';
+
+class MockQuizApiService {
+  getRandomQuestion() {
+    return of(null);
+  }
+}
 
 describe('BibleQuizPage', () => {
-  beforeEach(() => TestBed.configureTestingModule({ imports: [BibleQuizPage] }));
+  beforeEach(() =>
+    TestBed.configureTestingModule({
+      imports: [BibleQuizPage],
+      providers: [{ provide: BibleQuizApiService, useClass: MockQuizApiService }],
+    })
+  );
 
   it('should create', () => {
     const fixture = TestBed.createComponent(BibleQuizPage);

--- a/src/app/bible-quiz/bible-quiz.page.ts
+++ b/src/app/bible-quiz/bible-quiz.page.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { HttpClientModule } from '@angular/common/http';
 import {
   IonHeader,
   IonToolbar,
@@ -11,8 +12,11 @@ import {
   IonInput,
   IonList,
   IonButton,
+  IonRadio,
+  IonRadioGroup,
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
+import { BibleQuizApiService } from '../services/bible-quiz-api.service';
 import { BibleQuestion } from '../models/bible-quiz';
 
 @Component({
@@ -21,6 +25,7 @@ import { BibleQuestion } from '../models/bible-quiz';
   imports: [
     CommonModule,
     FormsModule,
+    HttpClientModule,
     IonHeader,
     IonToolbar,
     IonTitle,
@@ -30,6 +35,8 @@ import { BibleQuestion } from '../models/bible-quiz';
     IonInput,
     IonList,
     IonButton,
+    IonRadio,
+    IonRadioGroup,
   ],
   templateUrl: './bible-quiz.page.html',
   styleUrls: ['./bible-quiz.page.scss'],
@@ -38,10 +45,13 @@ export class BibleQuizPage implements OnInit {
   question: BibleQuestion | null = null;
   answer = '';
 
-  constructor(private fb: FirebaseService) {}
+  constructor(
+    private fb: FirebaseService,
+    private api: BibleQuizApiService
+  ) {}
 
-  async ngOnInit() {
-    this.question = await this.fb.getRandomBibleQuestion();
+  ngOnInit() {
+    this.api.getRandomQuestion().subscribe((q) => (this.question = q));
   }
 
   async submit() {

--- a/src/app/models/bible-quiz.ts
+++ b/src/app/models/bible-quiz.ts
@@ -1,6 +1,11 @@
 export interface BibleQuestion {
   id?: string;
   text: string;
+  options?: string[];
+  answer?: string;
+  reference?: string;
+  month?: string;
+  quarter?: string;
 }
 
 export interface BibleQuizResult {

--- a/src/app/services/bible-quiz-api.service.ts
+++ b/src/app/services/bible-quiz-api.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+import { BibleQuestion } from '../models/bible-quiz';
+
+@Injectable({ providedIn: 'root' })
+export class BibleQuizApiService {
+  constructor(private http: HttpClient) {}
+
+  getRandomQuestion(): Observable<BibleQuestion> {
+    return this.http.get<BibleQuestion>(`${environment.apiUrl}/bible-quiz/random`);
+  }
+}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -5,4 +5,5 @@ export const environment = {
     authDomain: 'YOUR_AUTH_DOMAIN',
     projectId: 'YOUR_PROJECT_ID',
   },
+  apiUrl: 'https://api.example.com'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -12,7 +12,8 @@ export const environment = {
     storageBucket: "your-project-id.appspot.com",
     messagingSenderId: "1234567890",
     appId: "1:1234567890:web:abc123xyz"
-  }
+  },
+  apiUrl: 'https://api.example.com'
 };
 
 


### PR DESCRIPTION
## Summary
- add `BibleQuizApiService` to load quiz questions from a REST API
- extend `BibleQuestion` model with answer, options and reference fields
- update bible quiz page to use the new API service and show radio options
- mock quiz API in unit tests
- expose `apiUrl` in environment files

## Testing
- `npm test` *(fails: `ng: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685e06669a188327bbb1ad6685dbe577