### PR TITLE
Update quiz API integration

### DIFF
--- a/src/app/bible-quiz/bible-quiz.page.spec.ts
+++ b/src/app/bible-quiz/bible-quiz.page.spec.ts
@@ -4,7 +4,7 @@ import { BibleQuizPage } from './bible-quiz.page';
 import { BibleQuizApiService } from '../services/bible-quiz-api.service';
 
 class MockQuizApiService {
-  getRandomQuestion() {
+  getTodayQuiz() {
     return of(null);
   }
 }

--- a/src/app/bible-quiz/bible-quiz.page.ts
+++ b/src/app/bible-quiz/bible-quiz.page.ts
@@ -51,7 +51,7 @@ export class BibleQuizPage implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.api.getRandomQuestion().subscribe((q) => (this.question = q));
+    this.api.getTodayQuiz().subscribe((q) => (this.question = q));
   }
 
   async submit() {
@@ -60,13 +60,12 @@ export class BibleQuizPage implements OnInit {
       return;
     }
     const user = this.fb.auth.currentUser;
-    await this.fb.saveBibleQuiz({
-      question: this.question!,
-      answer: this.answer,
-      score: 200,
-      userId: user ? user.uid : null,
-      date: new Date().toISOString(),
-    });
-    console.log('Quiz saved');
+    this.api
+      .submitQuiz({
+        questionId: this.question.id,
+        answer: this.answer,
+        userId: user ? user.uid : null,
+      })
+      .subscribe(() => console.log('Quiz submitted'));
   }
 }

--- a/src/app/services/bible-quiz-api.service.ts
+++ b/src/app/services/bible-quiz-api.service.ts
@@ -2,13 +2,21 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
-import { BibleQuestion } from '../models/bible-quiz';
+import { BibleQuestion, BibleQuizResult } from '../models/bible-quiz';
 
 @Injectable({ providedIn: 'root' })
 export class BibleQuizApiService {
   constructor(private http: HttpClient) {}
 
-  getRandomQuestion(): Observable<BibleQuestion> {
-    return this.http.get<BibleQuestion>(`${environment.apiUrl}/bible-quiz/random`);
+  getTodayQuiz(): Observable<BibleQuestion> {
+    return this.http.get<BibleQuestion>(`${environment.apiUrl}/quizzes/today`);
+  }
+
+  submitQuiz(data: unknown): Observable<unknown> {
+    return this.http.post(`${environment.apiUrl}/quizzes/submit`, data);
+  }
+
+  getHistory(childId: string): Observable<BibleQuizResult[]> {
+    return this.http.get<BibleQuizResult[]>(`${environment.apiUrl}/quizzes/history/${childId}`);
   }
 }


### PR DESCRIPTION
## Summary
- wire up quiz pages to the new Express routes
- adjust quiz page unit tests

## Testing
- `npx ng test` *(fails: 403 Forbidden while downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_685e07c97bdc8327bb7175e990ed2eab