### PR TITLE
Fix HttpClient injection for Bible quiz

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,6 @@
 import { bootstrapApplication } from '@angular/platform-browser';
+import { importProvidersFrom } from '@angular/core';
+import { HttpClientModule } from '@angular/common/http';
 import {
   RouteReuseStrategy,
   provideRouter,
@@ -40,5 +42,6 @@ bootstrapApplication(AppComponent, {
     { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
     provideIonicAngular(),
     provideRouter(routes, withPreloading(PreloadAllModules)),
+    importProvidersFrom(HttpClientModule),
   ],
 });


### PR DESCRIPTION
## Summary
- include `HttpClientModule` when bootstrapping the app

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e09291a048327b33bfb4adadc10cb