### PR TITLE
Switch quiz to Firebase service

### DIFF
--- a/src/app/bible-quiz/bible-quiz.page.spec.ts
+++ b/src/app/bible-quiz/bible-quiz.page.spec.ts
@@ -1,19 +1,10 @@
 import { TestBed } from '@angular/core/testing';
-import { of } from 'rxjs';
 import { BibleQuizPage } from './bible-quiz.page';
-import { BibleQuizApiService } from '../services/bible-quiz-api.service';
-
-class MockQuizApiService {
-  getTodayQuiz() {
-    return of(null);
-  }
-}
 
 describe('BibleQuizPage', () => {
   beforeEach(() =>
     TestBed.configureTestingModule({
       imports: [BibleQuizPage],
-      providers: [{ provide: BibleQuizApiService, useClass: MockQuizApiService }],
     })
   );
 

--- a/src/app/bible-quiz/bible-quiz.page.ts
+++ b/src/app/bible-quiz/bible-quiz.page.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { HttpClientModule } from '@angular/common/http';
 import {
   IonHeader,
   IonToolbar,
@@ -16,7 +15,6 @@ import {
   IonRadioGroup,
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
-import { BibleQuizApiService } from '../services/bible-quiz-api.service';
 import { BibleQuestion } from '../models/bible-quiz';
 
 @Component({
@@ -25,7 +23,6 @@ import { BibleQuestion } from '../models/bible-quiz';
   imports: [
     CommonModule,
     FormsModule,
-    HttpClientModule,
     IonHeader,
     IonToolbar,
     IonTitle,
@@ -45,13 +42,12 @@ export class BibleQuizPage implements OnInit {
   question: BibleQuestion | null = null;
   answer = '';
 
-  constructor(
-    private fb: FirebaseService,
-    private api: BibleQuizApiService
-  ) {}
+  constructor(private fb: FirebaseService) {}
 
   ngOnInit() {
-    this.api.getTodayQuiz().subscribe((q) => (this.question = q));
+    this.fb
+      .getRandomBibleQuestion()
+      .then((q) => (this.question = q));
   }
 
   async submit() {
@@ -60,12 +56,11 @@ export class BibleQuizPage implements OnInit {
       return;
     }
     const user = this.fb.auth.currentUser;
-    this.api
-      .submitQuiz({
-        questionId: this.question.id,
-        answer: this.answer,
-        userId: user ? user.uid : null,
-      })
-      .subscribe(() => console.log('Quiz submitted'));
+    await this.fb.saveBibleQuiz({
+      questionId: this.question.id,
+      answer: this.answer,
+      userId: user ? user.uid : null,
+    });
+    console.log('Quiz submitted');
   }
 }


### PR DESCRIPTION
## Summary
- remove unused API service from Bible quiz page
- fetch random quiz question directly from Firebase and save results

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e0aa3d9ac832799a19b88cb85d817