### PR TITLE
Fix Bible quiz submission data

### DIFF
--- a/src/app/bible-quiz/bible-quiz.page.ts
+++ b/src/app/bible-quiz/bible-quiz.page.ts
@@ -56,10 +56,14 @@ export class BibleQuizPage implements OnInit {
       return;
     }
     const user = this.fb.auth.currentUser;
+    const correctAnswer = (this.question.answer || '').trim().toLowerCase();
+    const userAnswer = this.answer.trim().toLowerCase();
     await this.fb.saveBibleQuiz({
-      questionId: this.question.id,
+      question: this.question,
       answer: this.answer,
+      score: correctAnswer && userAnswer === correctAnswer ? 200 : 0,
       userId: user ? user.uid : null,
+      date: new Date().toISOString(),
     });
     console.log('Quiz submitted');
   }


### PR DESCRIPTION
## Summary
- fix the quiz submission to match `BibleQuizResult`

## Testing
- `npm test --silent` *(fails: ng not found)*
- `npx ng test --watch=false --browsers=ChromeHeadless --no-progress` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ng)*

------
https://chatgpt.com/codex/tasks/task_e_685e0de4c3548327840e5e9cb5cdf2d8