### PR TITLE
Fix bible quiz question display

### DIFF
--- a/src/app/bible-quiz/bible-quiz.page.html
+++ b/src/app/bible-quiz/bible-quiz.page.html
@@ -9,7 +9,7 @@
   <ion-list *ngIf="question">
     <ion-item>
       <ion-label position="stacked">Question</ion-label>
-      <ion-label>{{ question.text }}</ion-label>
+      <ion-label>{{ question.text || question.question }}</ion-label>
     </ion-item>
     <ion-radio-group [(ngModel)]="answer" *ngIf="question.options?.length">
       <ion-item *ngFor="let opt of question.options">

--- a/src/app/models/bible-quiz.ts
+++ b/src/app/models/bible-quiz.ts
@@ -1,6 +1,12 @@
 export interface BibleQuestion {
   id?: string;
-  text: string;
+  /**
+   * Some questions use the `text` field while others
+   * were stored under the `question` key. Both are
+   * optional so the UI can fall back accordingly.
+   */
+  text?: string;
+  question?: string;
   options?: string[];
   answer?: string;
   reference?: string;


### PR DESCRIPTION
## Summary
- show question text from either `text` or `question` field
- document optional fields in `BibleQuestion` model

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e11cf90688327b773770e4378bb91