### PR TITLE
Fix Firestore writes using childId

### DIFF
--- a/src/app/academic-progress/academic-progress.page.ts
+++ b/src/app/academic-progress/academic-progress.page.ts
@@ -38,7 +38,7 @@ import { AcademicProgressEntry } from '../models/academic-progress';
   styleUrls: ['./academic-progress.page.scss'],
 })
 export class AcademicProgressPage {
-  form: Omit<AcademicProgressEntry, 'userId' | 'date'> = {
+  form: Omit<AcademicProgressEntry, 'childId' | 'date'> = {
     testScore: null as number | null,
     shareResult: false,
     needsHelp: false,
@@ -50,7 +50,7 @@ export class AcademicProgressPage {
     const user = this.fb.auth.currentUser;
     await this.fb.saveAcademicProgress({
       ...this.form,
-      userId: user ? user.uid : null,
+      childId: user ? user.uid : null,
       date: new Date().toISOString(),
     });
     console.log('Academic progress saved');

--- a/src/app/bible-quiz/bible-quiz.page.ts
+++ b/src/app/bible-quiz/bible-quiz.page.ts
@@ -62,7 +62,7 @@ export class BibleQuizPage implements OnInit {
       question: this.question,
       answer: this.answer,
       score: correctAnswer && userAnswer === correctAnswer ? 200 : 0,
-      userId: user ? user.uid : null,
+      childId: user ? user.uid : null,
       date: new Date().toISOString(),
     });
     console.log('Quiz submitted');

--- a/src/app/check-in/check-in.page.ts
+++ b/src/app/check-in/check-in.page.ts
@@ -29,7 +29,7 @@ import { DailyCheckin } from '../models/daily-checkin';
   styleUrls: ['./check-in.page.scss'],
 })
 export class CheckInPage {
-  form: Omit<DailyCheckin, 'userId' | 'parentId' | 'date'> = {
+  form: Omit<DailyCheckin, 'childId' | 'parentId' | 'date'> = {
     gratitude1: '',
     gratitude2: '',
     gratitude3: '',
@@ -51,7 +51,7 @@ export class CheckInPage {
     const parentId = user ? await this.fbService.getParentIdForChild(user.uid) : null;
     await this.fbService.saveDailyCheckin({
       ...this.form,
-      userId: user ? user.uid : null,
+      childId: user ? user.uid : null,
       parentId,
       date: new Date().toISOString(),
     });

--- a/src/app/essay-tracker/essay-tracker.page.ts
+++ b/src/app/essay-tracker/essay-tracker.page.ts
@@ -43,7 +43,7 @@ import { EssayEntry } from '../models/essay-entry';
   styleUrls: ['./essay-tracker.page.scss'],
 })
 export class EssayTrackerPage {
-  form: Omit<EssayEntry, 'userId' | 'date'> = {
+  form: Omit<EssayEntry, 'childId' | 'date'> = {
     title: '',
     progress: 'in progress',
     needHelp: false,
@@ -55,7 +55,7 @@ export class EssayTrackerPage {
     const user = this.fb.auth.currentUser;
     await this.fb.saveEssay({
       ...this.form,
-      userId: user ? user.uid : null,
+      childId: user ? user.uid : null,
       date: new Date().toISOString(),
     });
     console.log('Essay saved');

--- a/src/app/mental-status/mental-status.page.ts
+++ b/src/app/mental-status/mental-status.page.ts
@@ -39,7 +39,7 @@ import { MentalStatus } from '../models/mental-status';
   styleUrls: ['./mental-status.page.scss'],
 })
 export class MentalStatusPage {
-  form: Omit<MentalStatus, 'userId' | 'parentId' | 'date'> = {
+  form: Omit<MentalStatus, 'childId' | 'parentId' | 'date'> = {
     treatmentSchool: false,
     treatmentHome: false,
     bullied: false,
@@ -54,7 +54,7 @@ export class MentalStatusPage {
     const parentId = user ? await this.fb.getParentIdForChild(user.uid) : null;
     await this.fb.saveMentalStatus({
       ...this.form,
-      userId: user ? user.uid : null,
+      childId: user ? user.uid : null,
       parentId,
       date: new Date().toISOString(),
     });

--- a/src/app/models/academic-progress.ts
+++ b/src/app/models/academic-progress.ts
@@ -2,6 +2,6 @@ export interface AcademicProgressEntry {
   testScore: number | null;
   shareResult: boolean;
   needsHelp: boolean;
-  userId?: string | null;
+  childId?: string | null;
   date: string;
 }

--- a/src/app/models/bible-quiz.ts
+++ b/src/app/models/bible-quiz.ts
@@ -18,6 +18,6 @@ export interface BibleQuizResult {
   question: BibleQuestion;
   answer: string;
   score: number;
-  userId?: string | null;
+  childId?: string | null;
   date: string;
 }

--- a/src/app/models/daily-checkin.ts
+++ b/src/app/models/daily-checkin.ts
@@ -11,7 +11,7 @@ export interface DailyCheckin {
   treatment: string;
   needsHelp: boolean;
   helpRequest: string;
-  userId?: string | null;
+  childId?: string | null;
   parentId?: string | null;
   date: string;
 }

--- a/src/app/models/essay-entry.ts
+++ b/src/app/models/essay-entry.ts
@@ -2,6 +2,6 @@ export interface EssayEntry {
   title: string;
   progress: string;
   needHelp: boolean;
-  userId?: string | null;
+  childId?: string | null;
   date: string;
 }

--- a/src/app/models/mental-status.ts
+++ b/src/app/models/mental-status.ts
@@ -4,7 +4,7 @@ export interface MentalStatus {
   bullied: boolean;
   notifyParent: boolean;
   suggestions: string;
-  userId?: string | null;
+  childId?: string | null;
   parentId?: string | null;
   date: string;
 }

--- a/src/app/models/project-entry.ts
+++ b/src/app/models/project-entry.ts
@@ -5,6 +5,6 @@ export interface ProjectEntry {
   enjoyment: number;
   progress: string;
   quarter: string;
-  userId?: string | null;
+  childId?: string | null;
   date: string;
 }

--- a/src/app/project-tracker/project-tracker.page.ts
+++ b/src/app/project-tracker/project-tracker.page.ts
@@ -46,7 +46,7 @@ import { ProjectEntry } from '../models/project-entry';
 
 })
 export class ProjectTrackerPage {
-  form: Omit<ProjectEntry, 'userId' | 'date' | 'quarter'> = {
+  form: Omit<ProjectEntry, 'childId' | 'date' | 'quarter'> = {
     title: '',
     presentationDate: '',
     needsHelp: false,
@@ -66,7 +66,7 @@ export class ProjectTrackerPage {
     await this.fb.saveProject({
       ...this.form,
       quarter,
-      userId: user ? user.uid : null,
+      childId: user ? user.uid : null,
       date: new Date().toISOString(),
     });
     console.log('Project saved');

--- a/src/app/services/firebase.service.ts
+++ b/src/app/services/firebase.service.ts
@@ -81,16 +81,16 @@ export class FirebaseService {
 
   async saveDailyCheckin(data: DailyCheckin) {
     const docRef = await addDoc(collection(this.db, 'dailyCheckins'), data);
-    if (data.userId) {
-      await this.updateStreak(data.userId);
+    if (data.childId) {
+      await this.updateStreak(data.childId);
     }
     return docRef;
   }
 
   async saveMentalStatus(data: MentalStatus) {
     const docRef = await addDoc(collection(this.db, 'mentalStatus'), data);
-    if (data.userId) {
-      const parentId = await this.getParentIdForChild(data.userId);
+    if (data.childId) {
+      const parentId = await this.getParentIdForChild(data.childId);
       if (parentId && (data.bullied || data.notifyParent)) {
         await this.sendNotification(
           parentId,
@@ -103,8 +103,8 @@ export class FirebaseService {
 
   async saveBibleQuiz(data: BibleQuizResult) {
     const docRef = await addDoc(collection(this.db, 'bibleQuizzes'), data);
-    if (data.userId && data.score) {
-      await this.addPoints(data.userId, data.score);
+    if (data.childId && data.score) {
+      await this.addPoints(data.childId, data.score);
     }
     return docRef;
   }
@@ -142,13 +142,13 @@ export class FirebaseService {
     });
   }
 
-  async addPoints(userId: string, points: number) {
-    const ref = doc(this.db, 'userStats', userId);
+  async addPoints(childId: string, points: number) {
+    const ref = doc(this.db, 'userStats', childId);
     await setDoc(ref, { points: increment(points) }, { merge: true });
   }
 
-  async updateStreak(userId: string) {
-    const ref = doc(this.db, 'userStats', userId);
+  async updateStreak(childId: string) {
+    const ref = doc(this.db, 'userStats', childId);
     const snap = await getDoc(ref);
     const today = new Date().toISOString().split('T')[0];
     if (!snap.exists()) {


### PR DESCRIPTION
## Summary
- use `childId` instead of `userId` when writing quiz results and other records
- update Firestore service methods accordingly
- adjust all page components and models to match the new field name

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e24c952f48327bc10c322174f5f61