### PR TITLE
Revert IonPage changes

### DIFF
--- a/src/app/academic-progress/academic-progress.page.html
+++ b/src/app/academic-progress/academic-progress.page.html
@@ -1,6 +1,4 @@
 
-<ion-page>
-
   <ion-header>
     <ion-toolbar>
       <ion-title>Academic Progress</ion-title>
@@ -27,4 +25,3 @@
   </div>
   </ion-content>
 
-</ion-page>

--- a/src/app/academic-progress/academic-progress.page.ts
+++ b/src/app/academic-progress/academic-progress.page.ts
@@ -13,7 +13,6 @@ import {
   IonButton,
   IonCheckbox,
 } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { AcademicProgressEntry } from '../models/academic-progress';
 
@@ -26,7 +25,6 @@ import { AcademicProgressEntry } from '../models/academic-progress';
     IonHeader,
     IonToolbar,
     IonTitle,
-    IonPage,
     IonContent,
     IonItem,
     IonLabel,

--- a/src/app/bible-quiz/bible-quiz.page.html
+++ b/src/app/bible-quiz/bible-quiz.page.html
@@ -1,4 +1,3 @@
-<ion-page>
 
   <ion-header>
     <ion-toolbar>
@@ -10,7 +9,7 @@
   <ion-list *ngIf="question">
     <ion-item>
       <ion-label position="stacked">Question</ion-label>
-      <ion-text>{{ question.text || question.question }}</ion-text>
+      <ion-label>{{ question.text || question.question }}</ion-label>
     </ion-item>
     <ion-radio-group [(ngModel)]="answer" *ngIf="question.options?.length">
       <ion-item *ngFor="let opt of question.options">
@@ -28,4 +27,3 @@
   </div>
   </ion-content>
 
-</ion-page>

--- a/src/app/bible-quiz/bible-quiz.page.ts
+++ b/src/app/bible-quiz/bible-quiz.page.ts
@@ -13,9 +13,7 @@ import {
   IonButton,
   IonRadio,
   IonRadioGroup,
-  IonText,
 } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { BibleQuestion } from '../models/bible-quiz';
 
@@ -28,7 +26,6 @@ import { BibleQuestion } from '../models/bible-quiz';
     IonHeader,
     IonToolbar,
     IonTitle,
-    IonPage,
     IonContent,
     IonItem,
     IonLabel,
@@ -37,7 +34,6 @@ import { BibleQuestion } from '../models/bible-quiz';
     IonButton,
     IonRadio,
     IonRadioGroup,
-    IonText,
   ],
   templateUrl: './bible-quiz.page.html',
   styleUrls: ['./bible-quiz.page.scss'],

--- a/src/app/check-in/check-in.page.html
+++ b/src/app/check-in/check-in.page.html
@@ -1,6 +1,4 @@
 
-<ion-page>
-
   <ion-header>
     <ion-toolbar>
       <ion-title>Daily Check-In</ion-title>
@@ -79,4 +77,3 @@
   </div>
   </ion-content>
 
-</ion-page>

--- a/src/app/check-in/check-in.page.ts
+++ b/src/app/check-in/check-in.page.ts
@@ -2,7 +2,6 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import {  IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonTextarea, IonSegment, IonSegmentButton, IonCheckbox } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { DailyCheckin } from '../models/daily-checkin';
 
@@ -15,7 +14,6 @@ import { DailyCheckin } from '../models/daily-checkin';
     IonHeader,
     IonToolbar,
     IonTitle,
-    IonPage,
     IonContent,
     IonInput,
     IonItem,

--- a/src/app/child-account/child-account.page.html
+++ b/src/app/child-account/child-account.page.html
@@ -1,6 +1,4 @@
 
-<ion-page>
-
   <ion-header>
     <ion-toolbar>
       <ion-title>Create Child Account</ion-title>
@@ -25,4 +23,3 @@
   <ion-button expand="block" (click)="create()">Create</ion-button>
   </ion-content>
 
-</ion-page>

--- a/src/app/child-account/child-account.page.ts
+++ b/src/app/child-account/child-account.page.ts
@@ -2,7 +2,6 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
 
@@ -15,7 +14,6 @@ import { Router } from '@angular/router';
     IonHeader,
     IonToolbar,
     IonTitle,
-    IonPage,
     IonContent,
     IonInput,
     IonItem,

--- a/src/app/essay-tracker/essay-tracker.page.html
+++ b/src/app/essay-tracker/essay-tracker.page.html
@@ -1,6 +1,4 @@
 
-<ion-page>
-
   <ion-header>
     <ion-toolbar>
       <ion-title>Essay Tracker</ion-title>
@@ -31,4 +29,3 @@
   </div>
   </ion-content>
 
-</ion-page>

--- a/src/app/essay-tracker/essay-tracker.page.ts
+++ b/src/app/essay-tracker/essay-tracker.page.ts
@@ -16,7 +16,6 @@ import {
   IonSelectOption,
   IonCheckbox,
 } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { EssayEntry } from '../models/essay-entry';
 
@@ -30,7 +29,6 @@ import { EssayEntry } from '../models/essay-entry';
     IonHeader,
     IonToolbar,
     IonTitle,
-    IonPage,
     IonContent,
     IonItem,
     IonLabel,

--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -1,5 +1,4 @@
-<ion-page>
-<ion-header [translucent]="true">
+  <ion-header [translucent]="true">
     <ion-toolbar>
       <ion-title>
         Kids Faith Tracker
@@ -68,6 +67,5 @@
         </ion-row>
       </ng-container>
     </ion-grid>
-</ion-content>
+  </ion-content>
 
-</ion-page>

--- a/src/app/home/home.page.ts
+++ b/src/app/home/home.page.ts
@@ -10,7 +10,6 @@ import {
   IonRow,
   IonCol,
 } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular/standalone';
 import { RoleService } from '../services/role.service';
 import { NgIf } from '@angular/common';
 
@@ -24,7 +23,6 @@ import { NgIf } from '@angular/common';
     IonToolbar,
     IonTitle,
     IonContent,
-    IonPage,
     IonButton,
     IonGrid,
     IonRow,

--- a/src/app/leaderboard/leaderboard.page.html
+++ b/src/app/leaderboard/leaderboard.page.html
@@ -1,6 +1,4 @@
 
-<ion-page>
-
   <ion-header>
     <ion-toolbar>
       <ion-title>Leaderboard</ion-title>
@@ -15,4 +13,3 @@
   </ion-list>
   </ion-content>
 
-</ion-page>

--- a/src/app/leaderboard/leaderboard.page.ts
+++ b/src/app/leaderboard/leaderboard.page.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {
-
+  
   IonHeader,
   IonToolbar,
   IonTitle,
@@ -10,7 +10,6 @@ import {
   IonItem,
   IonLabel,
 } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { LeaderboardEntry } from '../models/user-stats';
 
@@ -23,7 +22,6 @@ import { LeaderboardEntry } from '../models/user-stats';
     IonHeader,
     IonToolbar,
     IonTitle,
-    IonPage,
     IonContent,
     IonList,
     IonItem,

--- a/src/app/login/login.page.html
+++ b/src/app/login/login.page.html
@@ -1,6 +1,4 @@
 
-<ion-page>
-
   <ion-header>
     <ion-toolbar>
       <ion-title>Login</ion-title>
@@ -31,4 +29,3 @@
   </ion-button>
   </ion-content>
 
-</ion-page>

--- a/src/app/login/login.page.ts
+++ b/src/app/login/login.page.ts
@@ -2,7 +2,6 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonSelect, IonSelectOption } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular/standalone';
 import { RouterLink } from '@angular/router';
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
@@ -18,7 +17,6 @@ import { RoleService } from '../services/role.service';
     IonHeader,
     IonToolbar,
     IonTitle,
-    IonPage,
     IonContent,
     IonInput,
     IonItem,

--- a/src/app/mental-status/mental-status.page.html
+++ b/src/app/mental-status/mental-status.page.html
@@ -1,6 +1,4 @@
 
-<ion-page>
-
   <ion-header>
     <ion-toolbar>
       <ion-title>Mental & Emotional Status</ion-title>
@@ -35,4 +33,3 @@
   </div>
   </ion-content>
 
-</ion-page>

--- a/src/app/mental-status/mental-status.page.ts
+++ b/src/app/mental-status/mental-status.page.ts
@@ -14,7 +14,6 @@ import {
   IonButton,
   IonTextarea,
 } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { MentalStatus } from '../models/mental-status';
 
@@ -28,7 +27,6 @@ import { MentalStatus } from '../models/mental-status';
     IonHeader,
     IonToolbar,
     IonTitle,
-    IonPage,
     IonContent,
     IonItem,
     IonLabel,

--- a/src/app/project-tracker/project-tracker.page.html
+++ b/src/app/project-tracker/project-tracker.page.html
@@ -1,4 +1,4 @@
-<ion-page>
+<div class="ion-page">
   <ion-header>
     <ion-toolbar>
       <ion-title>Project Tracker</ion-title>
@@ -41,4 +41,4 @@
       <ion-button expand="block" (click)="submit()">Submit</ion-button>
     </div>
   </ion-content>
-</ion-page>
+</div>

--- a/src/app/project-tracker/project-tracker.page.ts
+++ b/src/app/project-tracker/project-tracker.page.ts
@@ -14,9 +14,8 @@ import {
   IonCheckbox,
   IonSelect,
   IonSelectOption,
-
+  
 } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { ProjectEntry } from '../models/project-entry';
 
@@ -29,7 +28,6 @@ import { ProjectEntry } from '../models/project-entry';
     IonHeader,
     IonToolbar,
     IonTitle,
-    IonPage,
     IonContent,
     IonItem,
     IonLabel,

--- a/src/app/register/register.page.html
+++ b/src/app/register/register.page.html
@@ -1,6 +1,4 @@
 
-<ion-page>
-
   <ion-header>
     <ion-toolbar>
       <ion-title>Register</ion-title>
@@ -24,4 +22,3 @@
   </ion-button>
   </ion-content>
 
-</ion-page>

--- a/src/app/register/register.page.ts
+++ b/src/app/register/register.page.ts
@@ -2,7 +2,6 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList } from '@ionic/angular/standalone';
-import { IonPage } from '@ionic/angular/standalone';
 import { RouterLink } from '@angular/router';
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
@@ -17,7 +16,6 @@ import { Router } from '@angular/router';
     IonHeader,
     IonToolbar,
     IonTitle,
-    IonPage,
     IonContent,
     IonInput,
     IonItem,


### PR DESCRIPTION
## Summary
- revert IonPage wrappers introduced in `fix-missing-headers-in-ui`

## Testing
- `npm test --silent` *(fails: ng not found)*
- `npm run lint --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e2e3f5e64832795e2c23832a4deb6