### PR TITLE
Add quiz history view and API integration

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -20,6 +20,13 @@ export const routes: Routes = [
           import('./bible-quiz/bible-quiz.page').then((m) => m.BibleQuizPage),
       },
       {
+        path: 'quiz-history',
+        loadComponent: () =>
+          import('./quiz-history/quiz-history.page').then(
+            (m) => m.QuizHistoryPage
+          ),
+      },
+      {
         path: 'essay-tracker',
         loadComponent: () =>
           import('./essay-tracker/essay-tracker.page').then(

--- a/src/app/bible-quiz/bible-quiz.page.ts
+++ b/src/app/bible-quiz/bible-quiz.page.ts
@@ -14,7 +14,7 @@ import {
   IonRadio,
   IonRadioGroup,
 } from '@ionic/angular/standalone';
-import { FirebaseService } from '../services/firebase.service';
+import { BibleQuizApiService } from '../services/bible-quiz-api.service';
 import { BibleQuestion } from '../models/bible-quiz';
 
 @Component({
@@ -42,29 +42,21 @@ export class BibleQuizPage implements OnInit {
   question: BibleQuestion | null = null;
   answer = '';
 
-  constructor(private fb: FirebaseService) {}
+  constructor(private api: BibleQuizApiService) {}
 
   ngOnInit() {
-    this.fb
-      .getRandomBibleQuestion()
-      .then((q) => (this.question = q));
+    this.api.getTodayQuiz().subscribe((q) => (this.question = q));
   }
 
-  async submit() {
+  submit() {
     if (!this.question) {
       console.error('No quiz question available');
       return;
     }
-    const user = this.fb.auth.currentUser;
-    const correctAnswer = (this.question.answer || '').trim().toLowerCase();
-    const userAnswer = this.answer.trim().toLowerCase();
-    await this.fb.saveBibleQuiz({
-      question: this.question,
-      answer: this.answer,
-      score: correctAnswer && userAnswer === correctAnswer ? 200 : 0,
-      childId: user ? user.uid : null,
-      date: new Date().toISOString(),
-    });
-    console.log('Quiz submitted');
+    this.api
+      .submitQuiz({ questionId: this.question.id, answer: this.answer })
+      .subscribe(() => {
+        console.log('Quiz submitted');
+      });
   }
 }

--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -64,6 +64,9 @@
           <ion-col size="6">
           <ion-button class="tile-button" routerLink="/tabs/leaderboard" expand="block">Leaderboard</ion-button>
           </ion-col>
+          <ion-col size="6">
+          <ion-button class="tile-button" routerLink="/tabs/quiz-history" expand="block">Quiz History</ion-button>
+          </ion-col>
         </ion-row>
       </ng-container>
     </ion-grid>

--- a/src/app/quiz-history/quiz-history.page.html
+++ b/src/app/quiz-history/quiz-history.page.html
@@ -1,0 +1,17 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Quiz History</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+  <ion-list>
+    <ion-item *ngFor="let r of results">
+      <ion-label>
+        <h2>{{ r.question.text || r.question.question }}</h2>
+        <p>Your Answer: {{ r.answer }} - Score: {{ r.score }}</p>
+        <p>{{ r.date | date:'shortDate' }}</p>
+      </ion-label>
+    </ion-item>
+  </ion-list>
+</ion-content>

--- a/src/app/quiz-history/quiz-history.page.ts
+++ b/src/app/quiz-history/quiz-history.page.ts
@@ -1,0 +1,48 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonContent,
+  IonList,
+  IonItem,
+  IonLabel,
+} from '@ionic/angular/standalone';
+import { firstValueFrom } from 'rxjs';
+import { BibleQuizApiService } from '../services/bible-quiz-api.service';
+import { FirebaseService } from '../services/firebase.service';
+import { BibleQuizResult } from '../models/bible-quiz';
+
+@Component({
+  selector: 'app-quiz-history',
+  standalone: true,
+  imports: [
+    CommonModule,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
+    IonContent,
+    IonList,
+    IonItem,
+    IonLabel,
+  ],
+  templateUrl: './quiz-history.page.html',
+  styleUrls: ['./quiz-history.page.scss'],
+})
+export class QuizHistoryPage implements OnInit {
+  results: BibleQuizResult[] = [];
+
+  constructor(
+    private api: BibleQuizApiService,
+    private fb: FirebaseService
+  ) {}
+
+  async ngOnInit() {
+    const user = this.fb.auth.currentUser;
+    if (!user) {
+      return;
+    }
+    this.results = await firstValueFrom(this.api.getHistory(user.uid));
+  }
+}

--- a/src/app/services/auth.interceptor.ts
+++ b/src/app/services/auth.interceptor.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest,
+} from '@angular/common/http';
+import { Observable, from } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import { FirebaseService } from './firebase.service';
+
+@Injectable()
+export class AuthInterceptor implements HttpInterceptor {
+  constructor(private fb: FirebaseService) {}
+
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    const user = this.fb.auth.currentUser;
+    if (!user) {
+      return next.handle(req);
+    }
+    return from(user.getIdToken()).pipe(
+      switchMap((token) => {
+        const authReq = req.clone({
+          setHeaders: { Authorization: `Bearer ${token}` },
+        });
+        return next.handle(authReq);
+      })
+    );
+  }
+}

--- a/src/app/services/bible-quiz-api.service.ts
+++ b/src/app/services/bible-quiz-api.service.ts
@@ -8,15 +8,22 @@ import { BibleQuestion, BibleQuizResult } from '../models/bible-quiz';
 export class BibleQuizApiService {
   constructor(private http: HttpClient) {}
 
+  /**
+   * All quiz related endpoints are served under the `/api` prefix.
+   */
   getTodayQuiz(): Observable<BibleQuestion> {
-    return this.http.get<BibleQuestion>(`${environment.apiUrl}/quizzes/today`);
+    return this.http.get<BibleQuestion>(
+      `${environment.apiUrl}/api/quizzes/today`
+    );
   }
 
   submitQuiz(data: unknown): Observable<unknown> {
-    return this.http.post(`${environment.apiUrl}/quizzes/submit`, data);
+    return this.http.post(`${environment.apiUrl}/api/quizzes/submit`, data);
   }
 
   getHistory(childId: string): Observable<BibleQuizResult[]> {
-    return this.http.get<BibleQuizResult[]>(`${environment.apiUrl}/quizzes/history/${childId}`);
+    return this.http.get<BibleQuizResult[]>(
+      `${environment.apiUrl}/api/quizzes/history/${childId}`
+    );
   }
 }

--- a/src/app/tabs/tabs.page.html
+++ b/src/app/tabs/tabs.page.html
@@ -32,6 +32,10 @@
         <ion-icon name="list-outline"></ion-icon>
         <ion-label>Projects</ion-label>
       </ion-tab-button>
+      <ion-tab-button tab="quiz-history" href="/tabs/quiz-history">
+        <ion-icon name="time-outline"></ion-icon>
+        <ion-label>History</ion-label>
+      </ion-tab-button>
     </ng-template>
       <ion-tab-button tab="logout" href="/login" (click)="logout()">
         <ion-icon name="log-out-outline"></ion-icon>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { importProvidersFrom } from '@angular/core';
-import { HttpClientModule } from '@angular/common/http';
+import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
 import {
   RouteReuseStrategy,
   provideRouter,
@@ -21,7 +21,9 @@ import {
   logOutOutline,
   personAddOutline,
   trophyOutline,
+  timeOutline,
 } from 'ionicons/icons';
+import { AuthInterceptor } from './app/services/auth.interceptor';
 
 import { routes } from './app/app.routes';
 import { AppComponent } from './app/app.component';
@@ -35,6 +37,7 @@ addIcons({
   logOutOutline,
   personAddOutline,
   trophyOutline,
+  timeOutline,
 });
 
 bootstrapApplication(AppComponent, {
@@ -43,5 +46,6 @@ bootstrapApplication(AppComponent, {
     provideIonicAngular(),
     provideRouter(routes, withPreloading(PreloadAllModules)),
     importProvidersFrom(HttpClientModule),
+    { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true },
   ],
 });


### PR DESCRIPTION
## Summary
- integrate REST API for quiz operations
- add HTTP auth interceptor for Firebase ID tokens
- implement quiz history page for children
- link quiz history via tabs and home

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e3097dbcc8327befd712a0ce98d6e