### PR TITLE
Fix bible quiz fallback to Firebase

### DIFF
--- a/src/app/bible-quiz/bible-quiz.page.ts
+++ b/src/app/bible-quiz/bible-quiz.page.ts
@@ -54,7 +54,7 @@ export class BibleQuizPage implements OnInit {
       return;
     }
     this.api
-      .submitQuiz({ questionId: this.question.id, answer: this.answer })
+      .submitQuiz({ question: this.question, answer: this.answer })
       .subscribe(() => {
         console.log('Quiz submitted');
       });

--- a/src/app/services/bible-quiz-api.service.ts
+++ b/src/app/services/bible-quiz-api.service.ts
@@ -1,29 +1,56 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, from } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
 import { environment } from '../../environments/environment';
 import { BibleQuestion, BibleQuizResult } from '../models/bible-quiz';
+import { FirebaseService } from './firebase.service';
 
 @Injectable({ providedIn: 'root' })
 export class BibleQuizApiService {
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private fb: FirebaseService) {}
 
   /**
    * All quiz related endpoints are served under the `/api` prefix.
    */
   getTodayQuiz(): Observable<BibleQuestion> {
-    return this.http.get<BibleQuestion>(
-      `${environment.apiUrl}/api/quizzes/today`
-    );
+    return this.http
+      .get<BibleQuestion>(`${environment.apiUrl}/api/quizzes/today`)
+      .pipe(
+        catchError(() =>
+          from(this.fb.getRandomBibleQuestion()).pipe(
+            map((q) => q as BibleQuestion)
+          )
+        )
+      );
   }
 
-  submitQuiz(data: unknown): Observable<unknown> {
-    return this.http.post(`${environment.apiUrl}/api/quizzes/submit`, data);
+  submitQuiz(data: { question: BibleQuestion; answer: string }): Observable<unknown> {
+    return this.http
+      .post(`${environment.apiUrl}/api/quizzes/submit`, {
+        questionId: data.question.id,
+        answer: data.answer,
+      })
+      .pipe(
+        catchError(() => {
+          const score = this.fb.gradeQuizAnswer(data.question, data.answer);
+          const result: BibleQuizResult = {
+            question: data.question,
+            answer: data.answer,
+            score,
+            childId: this.fb.auth.currentUser?.uid || null,
+            date: new Date().toISOString(),
+          };
+          return from(this.fb.saveBibleQuiz(result));
+        })
+      );
   }
 
   getHistory(childId: string): Observable<BibleQuizResult[]> {
-    return this.http.get<BibleQuizResult[]>(
-      `${environment.apiUrl}/api/quizzes/history/${childId}`
-    );
+    return this.http
+      .get<BibleQuizResult[]>(`${environment.apiUrl}/api/quizzes/history/${childId}`)
+      .pipe(
+        catchError(() => from(this.fb.getBibleQuizHistory(childId)))
+      );
   }
 }

--- a/src/app/services/firebase.service.ts
+++ b/src/app/services/firebase.service.ts
@@ -134,6 +134,25 @@ export class FirebaseService {
     } as BibleQuestion;
   }
 
+  async getBibleQuizHistory(childId: string): Promise<BibleQuizResult[]> {
+    const q = query(
+      collection(this.db, 'bibleQuizzes'),
+      where('childId', '==', childId),
+      orderBy('date', 'desc')
+    );
+    const snap = await getDocs(q);
+    return snap.docs.map((d) => d.data() as BibleQuizResult);
+  }
+
+  gradeQuizAnswer(question: BibleQuestion, answer: string): number {
+    if (!question.answer) {
+      return 0;
+    }
+    return question.answer.trim().toLowerCase() === answer.trim().toLowerCase()
+      ? 200
+      : 0;
+  }
+
   async sendNotification(parentId: string, message: string) {
     return addDoc(collection(this.db, 'notifications'), {
       parentId,


### PR DESCRIPTION
## Summary
- make quiz service resilient if backend is unavailable
- grade quiz answers and save directly via Firebase when needed
- expose quiz history retrieval in Firebase service

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find packages)*

------
https://chatgpt.com/codex/tasks/task_e_685e3655365c8327aeb1addb0306a807