### PR TITLE
Fix mentor API offline fallbacks

### DIFF
--- a/src/app/services/firebase.service.ts
+++ b/src/app/services/firebase.service.ts
@@ -218,10 +218,10 @@ export class FirebaseService {
 
   async getChildForMentor(mentorId: string): Promise<string[]> {
     const q = query(
-      collection(this.db, 'mentorChildLink'),
+      collection(this.db, 'mentorChildLinks'),
       where('mentorId', '==', mentorId)
     );
-    const snap =await getDocs(q);
-    return snap.docs.map((d) => (d.data() as MentorChildLink).childId)
+    const snap = await getDocs(q);
+    return snap.docs.map((d) => (d.data() as MentorChildLink).childId);
   }
 }

--- a/src/app/services/mentor-api.service.ts
+++ b/src/app/services/mentor-api.service.ts
@@ -1,17 +1,35 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, from } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
 import { environment } from '../../environments/environment';
+import { FirebaseService } from './firebase.service';
 
 @Injectable({ providedIn: 'root' })
 export class MentorApiService {
-  constructor(private http: HttpClient) {}
- assignMentor(data: { mentorId: string; childId: string }): Observable<unknown> {
-   return this.http.post(`${environment.apiUrl}/api/mentors/assign`, data);
+  constructor(private http: HttpClient, private fb: FirebaseService) {}
+
+  assignMentor(data: { mentorId: string; childId: string }): Observable<unknown> {
+    return this.http
+      .post(`${environment.apiUrl}/api/mentors/assign`, data)
+      .pipe(
+        catchError(() =>
+          from(this.fb.assignMentor(data.mentorId, data.childId))
+        )
+      );
   }
- getChildren(mentorId: string): Observable<{ children: string[] }> {
-   return this.http.get<{ children: string[] }>(
-    `${environment.apiUrl}/api/mentors/${mentorId}/children`
-  );
- }
+
+  getChildren(mentorId: string): Observable<{ children: string[] }> {
+    return this.http
+      .get<{ children: string[] }>(
+        `${environment.apiUrl}/api/mentors/${mentorId}/children`
+      )
+      .pipe(
+        catchError(() =>
+          from(this.fb.getChildForMentor(mentorId)).pipe(
+            map((children) => ({ children }))
+          )
+        )
+      );
+  }
 }


### PR DESCRIPTION
## Summary
- fix mentor collection name
- add Firebase fallbacks to MentorApiService

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e4017d4608327aa28693ed54a22d0