### PR TITLE
Fix quiz submission payload

### DIFF
--- a/src/app/services/bible-quiz-api.service.ts
+++ b/src/app/services/bible-quiz-api.service.ts
@@ -26,11 +26,13 @@ export class BibleQuizApiService {
   }
 
   submitQuiz(data: { question: BibleQuestion; answer: string }): Observable<unknown> {
+    const payload = {
+      childId: this.fb.auth.currentUser?.uid || null,
+      quizId: data.question.id,
+      answers: [data.answer],
+    };
     return this.http
-      .post(`${environment.apiUrl}/api/quizzes/submit`, {
-        questionId: data.question.id,
-        answer: data.answer,
-      })
+      .post(`${environment.apiUrl}/api/quizzes/submit`, payload)
       .pipe(
         catchError(() => {
           const score = this.fb.gradeQuizAnswer(data.question, data.answer);


### PR DESCRIPTION
## Summary
- include childId, quizId and answers array when submitting quizzes

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e42031f6883278ec3cc4b8da8a127