### PR TITLE
Fix login default role for child account

### DIFF
--- a/src/app/login/login.page.ts
+++ b/src/app/login/login.page.ts
@@ -32,7 +32,9 @@ import { RoleService } from '../services/role.service';
 })
 export class LoginPage {
   form = { email: '', password: '' };
-  selectedRole = 'parent';
+  // Default to 'child' so that quiz and other child-specific features work
+  // correctly even if the role selector is not changed.
+  selectedRole = 'child';
 
   constructor(
     private fb: FirebaseService,


### PR DESCRIPTION
## Summary
- default login role to child so quiz history loads correctly

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e434291c48327a73ff5fa0b6f1281