### PR TITLE
Add Google authentication

### DIFF
--- a/src/app/login/login.page.html
+++ b/src/app/login/login.page.html
@@ -24,6 +24,9 @@
     </ion-item>
   </ion-list>
   <ion-button expand="block" (click)="login()">Login</ion-button>
+  <ion-button expand="block" color="secondary" (click)="loginWithGoogle()">
+    Login with Google
+  </ion-button>
   <ion-button routerLink="/register" fill="clear" expand="block">
     Don't have an account? Register
   </ion-button>

--- a/src/app/login/login.page.ts
+++ b/src/app/login/login.page.ts
@@ -47,4 +47,10 @@ export class LoginPage {
     this.roleSvc.setRole(this.selectedRole);
     this.router.navigateByUrl('/tabs');
   }
+
+  async loginWithGoogle() {
+    await this.fb.loginWithGoogle();
+    this.roleSvc.setRole(this.selectedRole);
+    this.router.navigateByUrl('/tabs');
+  }
 }

--- a/src/app/register/register.page.html
+++ b/src/app/register/register.page.html
@@ -17,6 +17,9 @@
     </ion-item>
   </ion-list>
   <ion-button expand="block" (click)="register()">Register</ion-button>
+  <ion-button expand="block" color="secondary" (click)="registerWithGoogle()">
+    Sign up with Google
+  </ion-button>
   <ion-button routerLink="/login" fill="clear" expand="block">
     Already have an account? Login
   </ion-button>

--- a/src/app/register/register.page.ts
+++ b/src/app/register/register.page.ts
@@ -36,4 +36,9 @@ export class RegisterPage {
     await this.fb.register(this.form.email, this.form.password);
     this.router.navigateByUrl('/login');
   }
+
+  async registerWithGoogle() {
+    await this.fb.loginWithGoogle();
+    this.router.navigateByUrl('/login');
+  }
 }

--- a/src/app/services/firebase.service.ts
+++ b/src/app/services/firebase.service.ts
@@ -7,6 +7,8 @@ import {
   signOut,
   Auth,
   UserCredential,
+  GoogleAuthProvider,
+  signInWithPopup,
 } from 'firebase/auth';
 import {
   getFirestore,
@@ -45,6 +47,14 @@ export class FirebaseService {
 
   login(email: string, password: string): Promise<UserCredential> {
     return signInWithEmailAndPassword(this.auth, email, password);
+  }
+
+  /**
+   * Sign in or register using Google authentication.
+   */
+  loginWithGoogle(): Promise<UserCredential> {
+    const provider = new GoogleAuthProvider();
+    return signInWithPopup(this.auth, provider);
   }
 
   logout(): Promise<void> {


### PR DESCRIPTION
## Summary
- add a `loginWithGoogle` utility to Firebase service
- add Google login to login page
- add Google signup to registration page

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb3851b2c8327bb1f28d1e6cac9b2