### PR TITLE
Fix logout tab navigation

### DIFF
--- a/src/app/tabs/tabs.page.html
+++ b/src/app/tabs/tabs.page.html
@@ -37,9 +37,9 @@
         <ion-label>History</ion-label>
       </ion-tab-button>
     </ng-template>
-      <ion-tab-button tab="logout" href="/login" (click)="logout()">
+      <ion-button fill="clear" (click)="logout()">
         <ion-icon name="log-out-outline"></ion-icon>
-      </ion-tab-button>
+      </ion-button>
   </ion-tab-bar>
 
 </ion-tabs>

--- a/src/app/tabs/tabs.page.ts
+++ b/src/app/tabs/tabs.page.ts
@@ -5,11 +5,11 @@ import {
  
   IonTabBar,
   IonTabButton,
+  IonButton,
   IonIcon,
   IonLabel,
-  IonRouterOutlet,
 } from '@ionic/angular/standalone';
-import { RouterLink, RouterOutlet } from '@angular/router';
+
 import { RoleService } from '../services/role.service';
 import { FirebaseService } from '../services/firebase.service';
 
@@ -17,11 +17,12 @@ import { FirebaseService } from '../services/firebase.service';
   selector: 'app-tabs',
   standalone: true,
   imports: [
-   
+
     CommonModule,
     IonTabs,
     IonTabBar,
     IonTabButton,
+    IonButton,
     IonIcon,
     IonLabel,
   ],


### PR DESCRIPTION
## Summary
- update logout tab to use a simple button instead of a tab route
- include `IonButton` in TabsPage

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686023e093448327beb4ca4564744a7d