### PR TITLE
Fix missing IonCheckbox import

### DIFF
--- a/src/app/mental-status/mental-status.page.ts
+++ b/src/app/mental-status/mental-status.page.ts
@@ -12,6 +12,7 @@ import {
   IonInput,
   IonList,
   IonButton,
+  IonCheckbox,
   IonTextarea,
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
@@ -30,9 +31,10 @@ import { MentalStatus } from '../models/mental-status';
     IonContent,
     IonItem,
     IonLabel,
-    
+
     IonList,
     IonButton,
+    IonCheckbox,
     IonTextarea,
   ],
   templateUrl: './mental-status.page.html',


### PR DESCRIPTION
## Summary
- import `IonCheckbox` and include it in the imports for `MentalStatusPage`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860258830188327a693d5106d3672a1