### PR TITLE
Improve bible quiz loading

### DIFF
--- a/src/app/bible-quiz/bible-quiz.page.html
+++ b/src/app/bible-quiz/bible-quiz.page.html
@@ -6,7 +6,8 @@
   </ion-header>
 
   <ion-content>
-  <ion-list *ngIf="question">
+  <ion-spinner *ngIf="loading" name="dots" class="center-spinner"></ion-spinner>
+  <ion-list *ngIf="!loading && question">
     <ion-item>
       <ion-label position="stacked">Question</ion-label>
       <ion-label>{{ question.text || question.question }}</ion-label>

--- a/src/app/bible-quiz/bible-quiz.page.scss
+++ b/src/app/bible-quiz/bible-quiz.page.scss
@@ -1,0 +1,5 @@
+ion-spinner.center-spinner {
+  display: flex;
+  justify-content: center;
+  margin-top: 2rem;
+}

--- a/src/app/bible-quiz/bible-quiz.page.ts
+++ b/src/app/bible-quiz/bible-quiz.page.ts
@@ -41,11 +41,25 @@ import { BibleQuestion } from '../models/bible-quiz';
 export class BibleQuizPage implements OnInit {
   question: BibleQuestion | null = null;
   answer = '';
+  loading = false;
 
   constructor(private api: BibleQuizApiService) {}
 
   ngOnInit() {
-    this.api.getTodayQuiz().subscribe((q) => (this.question = q));
+    this.loadQuiz();
+  }
+
+  loadQuiz() {
+    this.loading = true;
+    this.api.getTodayQuiz().subscribe({
+      next: (q) => {
+        this.question = q;
+        this.loading = false;
+      },
+      error: () => {
+        this.loading = false;
+      },
+    });
   }
 
   submit() {

--- a/src/app/services/bible-quiz-api.service.ts
+++ b/src/app/services/bible-quiz-api.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, from } from 'rxjs';
-import { catchError, map } from 'rxjs/operators';
+import { catchError, map, timeout } from 'rxjs/operators';
 import { environment } from '../../environments/environment';
 import { BibleQuestion, BibleQuizResult } from '../models/bible-quiz';
 import { FirebaseService } from './firebase.service';
@@ -26,6 +26,7 @@ export class BibleQuizApiService {
     return this.http
       .get<BibleQuestion>(`${environment.apiUrl}/api/quizzes/today`)
       .pipe(
+        timeout(5000),
         catchError(() =>
           from(this.fb.getRandomBibleQuestion()).pipe(
             map((q) => q as BibleQuestion)
@@ -56,6 +57,7 @@ export class BibleQuizApiService {
     return this.http
       .post(`${environment.apiUrl}/api/quizzes/submit`, payload)
       .pipe(
+        timeout(5000),
         catchError(() => {
           const result: BibleQuizResult = {
             question: data.question,
@@ -77,6 +79,7 @@ export class BibleQuizApiService {
     return this.http
       .get<BibleQuizResult[]>(`${environment.apiUrl}/api/quizzes/history/${childId}`)
       .pipe(
+        timeout(5000),
         catchError(() => from(this.fb.getBibleQuizHistory(childId)))
       );
   }


### PR DESCRIPTION
## Summary
- show a loading spinner for the Bible Quiz page
- timeout API calls in BibleQuizApiService so the fallback triggers quickly

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860271ba8e083279e211b4da38c96d9