### PR TITLE
Fix quiz history endpoint

### DIFF
--- a/src/app/services/bible-quiz-api.service.ts
+++ b/src/app/services/bible-quiz-api.service.ts
@@ -77,7 +77,7 @@ export class BibleQuizApiService {
     }
 
     return this.http
-      .get<BibleQuizResult[]>(`${environment.apiUrl}/api/quizzes/history/${childId}`)
+      .get<BibleQuizResult[]>(`${environment.apiUrl}/api/quizzes/${childId}/history`)
       .pipe(
         timeout(5000),
         catchError(() => from(this.fb.getBibleQuizHistory(childId)))


### PR DESCRIPTION
## Summary
- correct quiz history API path to use `/api/quizzes/<childId>/history`

## Testing
- `npm run lint` *(fails: `ng` not found)*
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860289b1b9c8327a2b691adadf25838