### PR TITLE
Fix missing home icon

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -29,15 +29,15 @@ import { routes } from './app/app.routes';
 import { AppComponent } from './app/app.component';
 
 addIcons({
-  calendarOutline,
-  helpOutline,
-  createOutline,
-  listOutline,
-  homeOutline,
-  logOutOutline,
-  personAddOutline,
-  trophyOutline,
-  timeOutline,
+  'calendar-outline': calendarOutline,
+  'help-outline': helpOutline,
+  'create-outline': createOutline,
+  'list-outline': listOutline,
+  'home-outline': homeOutline,
+  'log-out-outline': logOutOutline,
+  'person-add-outline': personAddOutline,
+  'trophy-outline': trophyOutline,
+  'time-outline': timeOutline,
 });
 
 bootstrapApplication(AppComponent, {


### PR DESCRIPTION
## Summary
- properly register Ionicons using dashed names so home icon loads

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686032ff150483279cc9bb83f482be1a