### PR TITLE
Add header to tabs layout

### DIFF
--- a/src/app/tabs/tabs.page.html
+++ b/src/app/tabs/tabs.page.html
@@ -1,3 +1,19 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-button routerLink="/tabs">
+        <ion-icon name="home-outline"></ion-icon>
+      </ion-button>
+    </ion-buttons>
+    <ion-title>Kids Faith Tracker</ion-title>
+    <ion-buttons slot="end">
+      <ion-button (click)="logout()">
+        <ion-icon name="log-out-outline"></ion-icon>
+      </ion-button>
+    </ion-buttons>
+  </ion-toolbar>
+</ion-header>
+
 <ion-tabs>
 
   <ion-tab-bar slot="bottom">

--- a/src/app/tabs/tabs.page.ts
+++ b/src/app/tabs/tabs.page.ts
@@ -2,9 +2,13 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {
   IonTabs,
- 
+
   IonTabBar,
   IonTabButton,
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonButtons,
   IonButton,
   IonIcon,
   IonLabel,
@@ -22,6 +26,10 @@ import { FirebaseService } from '../services/firebase.service';
     IonTabs,
     IonTabBar,
     IonTabButton,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
+    IonButtons,
     IonButton,
     IonIcon,
     IonLabel,


### PR DESCRIPTION
## Summary
- include a global header within `tabs.page.html`
- import header-related Ionic modules in `TabsPage`

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68603a5995348327823d369e5d6de96d