### PR TITLE
Add menu and breadcrumbs

### DIFF
--- a/src/app/academic-progress/academic-progress.page.html
+++ b/src/app/academic-progress/academic-progress.page.html
@@ -1,8 +1,12 @@
 
   <ion-header>
     <ion-toolbar>
+      <ion-buttons slot="start">
+        <ion-menu-button></ion-menu-button>
+      </ion-buttons>
       <ion-title>Academic Progress</ion-title>
     </ion-toolbar>
+    <app-breadcrumbs></app-breadcrumbs>
   </ion-header>
 
   <ion-content>

--- a/src/app/academic-progress/academic-progress.page.ts
+++ b/src/app/academic-progress/academic-progress.page.ts
@@ -5,6 +5,8 @@ import {
   IonHeader,
   IonToolbar,
   IonTitle,
+  IonButtons,
+  IonMenuButton,
   IonContent,
   IonItem,
   IonLabel,
@@ -15,6 +17,7 @@ import {
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { AcademicProgressEntry } from '../models/academic-progress';
+import { BreadcrumbsComponent } from '../components/breadcrumbs.component';
 
 @Component({
   selector: 'app-academic-progress',
@@ -25,6 +28,8 @@ import { AcademicProgressEntry } from '../models/academic-progress';
     IonHeader,
     IonToolbar,
     IonTitle,
+    IonButtons,
+    IonMenuButton,
     IonContent,
     IonItem,
     IonLabel,
@@ -32,7 +37,7 @@ import { AcademicProgressEntry } from '../models/academic-progress';
     IonList,
     IonButton,
     IonCheckbox,
-
+    BreadcrumbsComponent,
   ],
   templateUrl: './academic-progress.page.html',
   styleUrls: ['./academic-progress.page.scss'],

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,18 +1,42 @@
 <ion-app>
-  <ion-header *ngIf="loggedIn">
-    <ion-toolbar>
-      <ion-buttons slot="start">
-        <ion-button routerLink="/tabs">
-          <ion-icon name="home-outline"></ion-icon>
-        </ion-button>
-      </ion-buttons>
-      <ion-title>Kids Faith Tracker</ion-title>
-      <ion-buttons slot="end">
-        <ion-button (click)="logout()">
-          <ion-icon name="log-out-outline"></ion-icon>
-        </ion-button>
-      </ion-buttons>
-    </ion-toolbar>
-  </ion-header>
-  <ion-router-outlet></ion-router-outlet>
+  <ion-menu contentId="main">
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Menu</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content>
+      <ion-list>
+        <ion-menu-toggle auto-hide="true">
+          <ion-item routerLink="/tabs/home">Home</ion-item>
+          <ion-item routerLink="/tabs/check-in">Daily Check-In</ion-item>
+          <ion-item routerLink="/tabs/bible-quiz">Bible Quiz</ion-item>
+          <ion-item routerLink="/tabs/essay-tracker">Essay Tracker</ion-item>
+          <ion-item routerLink="/tabs/project-tracker">Project Tracker</ion-item>
+          <ion-item routerLink="/tabs/leaderboard">Leaderboard</ion-item>
+        </ion-menu-toggle>
+      </ion-list>
+    </ion-content>
+  </ion-menu>
+
+  <div id="main">
+    <ion-header *ngIf="loggedIn">
+      <ion-toolbar>
+        <ion-buttons slot="start">
+          <ion-menu-button></ion-menu-button>
+          <ion-button routerLink="/tabs">
+            <ion-icon name="home-outline"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+        <ion-title>Kids Faith Tracker</ion-title>
+        <ion-buttons slot="end">
+          <ion-button (click)="logout()">
+            <ion-icon name="log-out-outline"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+      </ion-toolbar>
+      <app-breadcrumbs></app-breadcrumbs>
+    </ion-header>
+    <ion-router-outlet></ion-router-outlet>
+  </div>
 </ion-app>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -4,7 +4,13 @@ import {
   IonRouterOutlet,
   IonHeader,
   IonToolbar,
+  IonMenu,
+  IonContent,
+  IonList,
+  IonItem,
+  IonMenuToggle,
   IonButtons,
+  IonMenuButton,
   IonButton,
   IonIcon,
   IonTitle,
@@ -13,6 +19,7 @@ import { Router } from '@angular/router';
 import { FirebaseService } from './services/firebase.service';
 import { RoleService } from './services/role.service';
 import { NgIf } from '@angular/common';
+import { BreadcrumbsComponent } from './components/breadcrumbs.component';
 
 @Component({
   selector: 'app-root',
@@ -20,13 +27,20 @@ import { NgIf } from '@angular/common';
   imports: [
     IonApp,
     IonRouterOutlet,
+    IonMenu,
+    IonContent,
+    IonList,
+    IonItem,
+    IonMenuToggle,
     IonHeader,
     IonToolbar,
     IonButtons,
+    IonMenuButton,
     IonButton,
     IonIcon,
     IonTitle,
-    NgIf
+    NgIf,
+    BreadcrumbsComponent
   ],
 })
 export class AppComponent {

--- a/src/app/bible-quiz/bible-quiz.page.html
+++ b/src/app/bible-quiz/bible-quiz.page.html
@@ -1,8 +1,12 @@
 
   <ion-header>
     <ion-toolbar>
+      <ion-buttons slot="start">
+        <ion-menu-button></ion-menu-button>
+      </ion-buttons>
       <ion-title>Bible Quiz</ion-title>
     </ion-toolbar>
+    <app-breadcrumbs></app-breadcrumbs>
   </ion-header>
 
   <ion-content>

--- a/src/app/bible-quiz/bible-quiz.page.ts
+++ b/src/app/bible-quiz/bible-quiz.page.ts
@@ -5,6 +5,8 @@ import {
   IonHeader,
   IonToolbar,
   IonTitle,
+  IonButtons,
+  IonMenuButton,
   IonContent,
   IonItem,
   IonLabel,
@@ -17,6 +19,7 @@ import {
 } from '@ionic/angular/standalone';
 import { BibleQuizApiService } from '../services/bible-quiz-api.service';
 import { BibleQuestion } from '../models/bible-quiz';
+import { BreadcrumbsComponent } from '../components/breadcrumbs.component';
 
 @Component({
   selector: 'app-bible-quiz',
@@ -27,6 +30,8 @@ import { BibleQuestion } from '../models/bible-quiz';
     IonHeader,
     IonToolbar,
     IonTitle,
+    IonButtons,
+    IonMenuButton,
     IonContent,
     IonItem,
     IonLabel,
@@ -35,7 +40,8 @@ import { BibleQuestion } from '../models/bible-quiz';
     IonButton,
     IonRadio,
     IonRadioGroup,
-    IonSpinner
+    IonSpinner,
+    BreadcrumbsComponent
   ],
   templateUrl: './bible-quiz.page.html',
   styleUrls: ['./bible-quiz.page.scss'],

--- a/src/app/check-in/check-in.page.html
+++ b/src/app/check-in/check-in.page.html
@@ -1,8 +1,12 @@
 
   <ion-header>
     <ion-toolbar>
+      <ion-buttons slot="start">
+        <ion-menu-button></ion-menu-button>
+      </ion-buttons>
       <ion-title>Daily Check-In</ion-title>
     </ion-toolbar>
+    <app-breadcrumbs></app-breadcrumbs>
   </ion-header>
 
   <ion-content>

--- a/src/app/check-in/check-in.page.ts
+++ b/src/app/check-in/check-in.page.ts
@@ -1,9 +1,10 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import {  IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonTextarea, IonSegment, IonSegmentButton, IonCheckbox } from '@ionic/angular/standalone';
+import {  IonHeader, IonToolbar, IonTitle, IonButtons, IonMenuButton, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonTextarea, IonSegment, IonSegmentButton, IonCheckbox } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { DailyCheckin } from '../models/daily-checkin';
+import { BreadcrumbsComponent } from '../components/breadcrumbs.component';
 
 @Component({
   selector: 'app-check-in',
@@ -14,6 +15,8 @@ import { DailyCheckin } from '../models/daily-checkin';
     IonHeader,
     IonToolbar,
     IonTitle,
+    IonButtons,
+    IonMenuButton,
     IonContent,
     IonInput,
     IonItem,
@@ -24,6 +27,7 @@ import { DailyCheckin } from '../models/daily-checkin';
     IonSegment,
     IonSegmentButton,
     IonCheckbox,
+    BreadcrumbsComponent,
   ],
   templateUrl: './check-in.page.html',
   styleUrls: ['./check-in.page.scss'],

--- a/src/app/child-account/child-account.page.html
+++ b/src/app/child-account/child-account.page.html
@@ -1,8 +1,12 @@
 
   <ion-header>
     <ion-toolbar>
+      <ion-buttons slot="start">
+        <ion-menu-button></ion-menu-button>
+      </ion-buttons>
       <ion-title>Create Child Account</ion-title>
     </ion-toolbar>
+    <app-breadcrumbs></app-breadcrumbs>
   </ion-header>
 
   <ion-content class="ion-padding">

--- a/src/app/child-account/child-account.page.ts
+++ b/src/app/child-account/child-account.page.ts
@@ -1,9 +1,10 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList } from '@ionic/angular/standalone';
+import { IonHeader, IonToolbar, IonTitle, IonButtons, IonMenuButton, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
+import { BreadcrumbsComponent } from '../components/breadcrumbs.component';
 
 @Component({
   selector: 'app-child-account',
@@ -14,12 +15,15 @@ import { Router } from '@angular/router';
     IonHeader,
     IonToolbar,
     IonTitle,
+    IonButtons,
+    IonMenuButton,
     IonContent,
     IonInput,
     IonItem,
     IonLabel,
     IonButton,
     IonList,
+    BreadcrumbsComponent,
   ],
   templateUrl: './child-account.page.html',
   styleUrls: ['./child-account.page.scss'],

--- a/src/app/components/breadcrumbs.component.ts
+++ b/src/app/components/breadcrumbs.component.ts
@@ -1,0 +1,49 @@
+import { Component } from '@angular/core';
+import { Router, NavigationEnd } from '@angular/router';
+import { IonBreadcrumb, IonBreadcrumbs } from '@ionic/angular/standalone';
+import { NgFor } from '@angular/common';
+import { filter } from 'rxjs/operators';
+
+@Component({
+  selector: 'app-breadcrumbs',
+  template: `
+    <ion-breadcrumbs>
+      <ion-breadcrumb *ngFor="let bc of breadcrumbs" [routerLink]="bc.url">
+        {{ bc.label }}
+      </ion-breadcrumb>
+    </ion-breadcrumbs>
+  `,
+  standalone: true,
+  imports: [IonBreadcrumbs, IonBreadcrumb, NgFor],
+})
+export class BreadcrumbsComponent {
+  breadcrumbs: { label: string; url: string }[] = [];
+
+  constructor(private router: Router) {
+    this.router.events
+      .pipe(filter((e) => e instanceof NavigationEnd))
+      .subscribe(() => this.build());
+    this.build();
+  }
+
+  private build() {
+    const segments = this.router.url.split('/').filter((s) => s);
+    let url = '';
+    this.breadcrumbs = [];
+    segments.forEach((seg, idx) => {
+      if (seg === 'home' && segments[idx - 1] === 'tabs') {
+        return;
+      }
+      url += '/' + seg;
+      const label = seg === 'tabs' ? 'Home' : this.format(seg);
+      this.breadcrumbs.push({ label, url });
+    });
+  }
+
+  private format(seg: string) {
+    return seg
+      .split('-')
+      .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+      .join(' ');
+  }
+}

--- a/src/app/essay-tracker/essay-tracker.page.html
+++ b/src/app/essay-tracker/essay-tracker.page.html
@@ -1,8 +1,12 @@
 
   <ion-header>
     <ion-toolbar>
+      <ion-buttons slot="start">
+        <ion-menu-button></ion-menu-button>
+      </ion-buttons>
       <ion-title>Essay Tracker</ion-title>
     </ion-toolbar>
+    <app-breadcrumbs></app-breadcrumbs>
   </ion-header>
 
   <ion-content>

--- a/src/app/essay-tracker/essay-tracker.page.ts
+++ b/src/app/essay-tracker/essay-tracker.page.ts
@@ -6,6 +6,8 @@ import {
   IonHeader,
   IonToolbar,
   IonTitle,
+  IonButtons,
+  IonMenuButton,
   IonContent,
   IonItem,
   IonLabel,
@@ -18,17 +20,20 @@ import {
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { EssayEntry } from '../models/essay-entry';
+import { BreadcrumbsComponent } from '../components/breadcrumbs.component';
 
 @Component({
   selector: 'app-essay-tracker',
   standalone: true,
   imports: [
-    
+
     CommonModule,
     FormsModule,
     IonHeader,
     IonToolbar,
     IonTitle,
+    IonButtons,
+    IonMenuButton,
     IonContent,
     IonItem,
     IonLabel,
@@ -38,6 +43,7 @@ import { EssayEntry } from '../models/essay-entry';
     IonSelect,
     IonSelectOption,
     IonCheckbox,
+    BreadcrumbsComponent,
   ],
   templateUrl: './essay-tracker.page.html',
   styleUrls: ['./essay-tracker.page.scss'],

--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -1,9 +1,13 @@
   <ion-header [translucent]="true">
     <ion-toolbar>
+      <ion-buttons slot="start">
+        <ion-menu-button></ion-menu-button>
+      </ion-buttons>
       <ion-title>
         Kids Faith Tracker
       </ion-title>
     </ion-toolbar>
+    <app-breadcrumbs></app-breadcrumbs>
   </ion-header>
 
   <ion-content [fullscreen]="true">

--- a/src/app/home/home.page.ts
+++ b/src/app/home/home.page.ts
@@ -4,6 +4,8 @@ import {
   IonHeader,
   IonToolbar,
   IonTitle,
+  IonButtons,
+  IonMenuButton,
   IonContent,
   IonButton,
   IonGrid,
@@ -13,6 +15,7 @@ import {
 } from '@ionic/angular/standalone';
 import { RoleService } from '../services/role.service';
 import { NgIf } from '@angular/common';
+import { BreadcrumbsComponent } from '../components/breadcrumbs.component';
 
 @Component({
   selector: 'app-home',
@@ -23,6 +26,8 @@ import { NgIf } from '@angular/common';
     IonHeader,
     IonToolbar,
     IonTitle,
+    IonButtons,
+    IonMenuButton,
     IonContent,
     IonButton,
     IonGrid,
@@ -30,7 +35,8 @@ import { NgIf } from '@angular/common';
     IonCol,
     RouterLink,
     NgIf,
-    IonSpinner
+    IonSpinner,
+    BreadcrumbsComponent
   ],
 })
 export class HomePage {

--- a/src/app/leaderboard/leaderboard.page.html
+++ b/src/app/leaderboard/leaderboard.page.html
@@ -1,8 +1,12 @@
 
   <ion-header>
     <ion-toolbar>
+      <ion-buttons slot="start">
+        <ion-menu-button></ion-menu-button>
+      </ion-buttons>
       <ion-title>Leaderboard</ion-title>
     </ion-toolbar>
+    <app-breadcrumbs></app-breadcrumbs>
   </ion-header>
 
   <ion-content>

--- a/src/app/leaderboard/leaderboard.page.ts
+++ b/src/app/leaderboard/leaderboard.page.ts
@@ -5,6 +5,8 @@ import {
   IonHeader,
   IonToolbar,
   IonTitle,
+  IonButtons,
+  IonMenuButton,
   IonContent,
   IonList,
   IonItem,
@@ -12,6 +14,7 @@ import {
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { LeaderboardEntry } from '../models/user-stats';
+import { BreadcrumbsComponent } from '../components/breadcrumbs.component';
 
 @Component({
   selector: 'app-leaderboard',
@@ -22,10 +25,13 @@ import { LeaderboardEntry } from '../models/user-stats';
     IonHeader,
     IonToolbar,
     IonTitle,
+    IonButtons,
+    IonMenuButton,
     IonContent,
     IonList,
     IonItem,
     IonLabel,
+    BreadcrumbsComponent,
   ],
   templateUrl: './leaderboard.page.html',
   styleUrls: ['./leaderboard.page.scss'],

--- a/src/app/login/login.page.html
+++ b/src/app/login/login.page.html
@@ -1,8 +1,12 @@
 
   <ion-header>
     <ion-toolbar>
+      <ion-buttons slot="start">
+        <ion-menu-button></ion-menu-button>
+      </ion-buttons>
       <ion-title>Login</ion-title>
     </ion-toolbar>
+    <app-breadcrumbs></app-breadcrumbs>
   </ion-header>
 
   <ion-content class="ion-padding">

--- a/src/app/login/login.page.ts
+++ b/src/app/login/login.page.ts
@@ -1,11 +1,12 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonSelect, IonSelectOption } from '@ionic/angular/standalone';
+import { IonHeader, IonToolbar, IonTitle, IonButtons, IonMenuButton, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonSelect, IonSelectOption } from '@ionic/angular/standalone';
 import { RouterLink } from '@angular/router';
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
 import { RoleService } from '../services/role.service';
+import { BreadcrumbsComponent } from '../components/breadcrumbs.component';
 
 @Component({
   selector: 'app-login',
@@ -17,6 +18,8 @@ import { RoleService } from '../services/role.service';
     IonHeader,
     IonToolbar,
     IonTitle,
+    IonButtons,
+    IonMenuButton,
     IonContent,
     IonInput,
     IonItem,
@@ -26,6 +29,7 @@ import { RoleService } from '../services/role.service';
     IonSelect,
     IonSelectOption,
     RouterLink,
+    BreadcrumbsComponent,
   ],
   templateUrl: './login.page.html',
   styleUrls: ['./login.page.scss'],

--- a/src/app/mental-status/mental-status.page.html
+++ b/src/app/mental-status/mental-status.page.html
@@ -1,8 +1,12 @@
 
   <ion-header>
     <ion-toolbar>
+      <ion-buttons slot="start">
+        <ion-menu-button></ion-menu-button>
+      </ion-buttons>
       <ion-title>Mental & Emotional Status</ion-title>
     </ion-toolbar>
+    <app-breadcrumbs></app-breadcrumbs>
   </ion-header>
 
   <ion-content>

--- a/src/app/mental-status/mental-status.page.ts
+++ b/src/app/mental-status/mental-status.page.ts
@@ -6,6 +6,8 @@ import {
   IonHeader,
   IonToolbar,
   IonTitle,
+  IonButtons,
+  IonMenuButton,
   IonContent,
   IonItem,
   IonLabel,
@@ -17,6 +19,7 @@ import {
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { MentalStatus } from '../models/mental-status';
+import { BreadcrumbsComponent } from '../components/breadcrumbs.component';
 
 @Component({
   selector: 'app-mental-status',
@@ -28,6 +31,8 @@ import { MentalStatus } from '../models/mental-status';
     IonHeader,
     IonToolbar,
     IonTitle,
+    IonButtons,
+    IonMenuButton,
     IonContent,
     IonItem,
     IonLabel,
@@ -36,6 +41,7 @@ import { MentalStatus } from '../models/mental-status';
     IonButton,
     IonCheckbox,
     IonTextarea,
+    BreadcrumbsComponent,
   ],
   templateUrl: './mental-status.page.html',
   styleUrls: ['./mental-status.page.scss'],

--- a/src/app/project-tracker/project-tracker.page.html
+++ b/src/app/project-tracker/project-tracker.page.html
@@ -1,8 +1,12 @@
 <div class="ion-page">
   <ion-header>
     <ion-toolbar>
+      <ion-buttons slot="start">
+        <ion-menu-button></ion-menu-button>
+      </ion-buttons>
       <ion-title>Project Tracker</ion-title>
     </ion-toolbar>
+    <app-breadcrumbs></app-breadcrumbs>
   </ion-header>
 
   <ion-content>

--- a/src/app/project-tracker/project-tracker.page.ts
+++ b/src/app/project-tracker/project-tracker.page.ts
@@ -5,6 +5,8 @@ import {
   IonHeader,
   IonToolbar,
   IonTitle,
+  IonButtons,
+  IonMenuButton,
   IonContent,
   IonItem,
   IonLabel,
@@ -18,6 +20,7 @@ import {
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { ProjectEntry } from '../models/project-entry';
+import { BreadcrumbsComponent } from '../components/breadcrumbs.component';
 
 @Component({
   selector: 'app-project-tracker',
@@ -28,6 +31,8 @@ import { ProjectEntry } from '../models/project-entry';
     IonHeader,
     IonToolbar,
     IonTitle,
+    IonButtons,
+    IonMenuButton,
     IonContent,
     IonItem,
     IonLabel,
@@ -38,6 +43,7 @@ import { ProjectEntry } from '../models/project-entry';
     IonSelect,
     IonSelectOption,
     CommonModule,
+    BreadcrumbsComponent,
     ReactiveFormsModule
   ],
   templateUrl: './project-tracker.page.html',

--- a/src/app/quiz-history/quiz-history.page.html
+++ b/src/app/quiz-history/quiz-history.page.html
@@ -1,7 +1,11 @@
 <ion-header>
   <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-menu-button></ion-menu-button>
+    </ion-buttons>
     <ion-title>Quiz History</ion-title>
   </ion-toolbar>
+  <app-breadcrumbs></app-breadcrumbs>
 </ion-header>
 
 <ion-content>

--- a/src/app/quiz-history/quiz-history.page.ts
+++ b/src/app/quiz-history/quiz-history.page.ts
@@ -4,6 +4,8 @@ import {
   IonHeader,
   IonToolbar,
   IonTitle,
+  IonButtons,
+  IonMenuButton,
   IonContent,
   IonList,
   IonItem,
@@ -13,6 +15,7 @@ import { firstValueFrom } from 'rxjs';
 import { BibleQuizApiService } from '../services/bible-quiz-api.service';
 import { FirebaseService } from '../services/firebase.service';
 import { BibleQuizResult } from '../models/bible-quiz';
+import { BreadcrumbsComponent } from '../components/breadcrumbs.component';
 
 @Component({
   selector: 'app-quiz-history',
@@ -22,10 +25,13 @@ import { BibleQuizResult } from '../models/bible-quiz';
     IonHeader,
     IonToolbar,
     IonTitle,
+    IonButtons,
+    IonMenuButton,
     IonContent,
     IonList,
     IonItem,
     IonLabel,
+    BreadcrumbsComponent,
   ],
   templateUrl: './quiz-history.page.html',
   styleUrls: ['./quiz-history.page.scss'],

--- a/src/app/register/register.page.html
+++ b/src/app/register/register.page.html
@@ -1,8 +1,12 @@
 
   <ion-header>
     <ion-toolbar>
+      <ion-buttons slot="start">
+        <ion-menu-button></ion-menu-button>
+      </ion-buttons>
       <ion-title>Register</ion-title>
     </ion-toolbar>
+    <app-breadcrumbs></app-breadcrumbs>
   </ion-header>
 
   <ion-content class="ion-padding">

--- a/src/app/register/register.page.ts
+++ b/src/app/register/register.page.ts
@@ -1,10 +1,11 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList } from '@ionic/angular/standalone';
+import { IonHeader, IonToolbar, IonTitle, IonButtons, IonMenuButton, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList } from '@ionic/angular/standalone';
 import { RouterLink } from '@angular/router';
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
+import { BreadcrumbsComponent } from '../components/breadcrumbs.component';
 
 @Component({
   selector: 'app-register',
@@ -16,6 +17,8 @@ import { Router } from '@angular/router';
     IonHeader,
     IonToolbar,
     IonTitle,
+    IonButtons,
+    IonMenuButton,
     IonContent,
     IonInput,
     IonItem,
@@ -23,6 +26,7 @@ import { Router } from '@angular/router';
     IonButton,
     IonList,
     RouterLink,
+    BreadcrumbsComponent,
   ],
   templateUrl: './register.page.html',
   styleUrls: ['./register.page.scss'],

--- a/src/app/tabs/tabs.page.html
+++ b/src/app/tabs/tabs.page.html
@@ -1,6 +1,7 @@
 <ion-header>
   <ion-toolbar>
     <ion-buttons slot="start">
+      <ion-menu-button></ion-menu-button>
       <ion-button routerLink="/tabs">
         <ion-icon name="home-outline"></ion-icon>
       </ion-button>
@@ -12,6 +13,7 @@
       </ion-button>
     </ion-buttons>
   </ion-toolbar>
+  <app-breadcrumbs></app-breadcrumbs>
 </ion-header>
 
 <ion-tabs>

--- a/src/app/tabs/tabs.page.ts
+++ b/src/app/tabs/tabs.page.ts
@@ -9,6 +9,7 @@ import {
   IonToolbar,
   IonTitle,
   IonButtons,
+  IonMenuButton,
   IonButton,
   IonIcon,
   IonLabel,
@@ -16,6 +17,7 @@ import {
 
 import { RoleService } from '../services/role.service';
 import { FirebaseService } from '../services/firebase.service';
+import { BreadcrumbsComponent } from '../components/breadcrumbs.component';
 
 @Component({
   selector: 'app-tabs',
@@ -30,9 +32,11 @@ import { FirebaseService } from '../services/firebase.service';
     IonToolbar,
     IonTitle,
     IonButtons,
+    IonMenuButton,
     IonButton,
     IonIcon,
     IonLabel,
+    BreadcrumbsComponent,
   ],
   templateUrl: './tabs.page.html',
   styleUrls: ['./tabs.page.scss'],


### PR DESCRIPTION
## Summary
- add BreadcrumbsComponent to show navigation trail
- implement global `ion-menu` and `ion-menu-button`
- show breadcrumbs and menu button on every page

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68603e4450508327b44522a2431ac267