### PR TITLE
Fix breadcrumbs routerLink directive

### DIFF
--- a/src/app/components/breadcrumbs.component.ts
+++ b/src/app/components/breadcrumbs.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { Router, NavigationEnd } from '@angular/router';
+import { Router, NavigationEnd, RouterLink } from '@angular/router';
 import { IonBreadcrumb, IonBreadcrumbs } from '@ionic/angular/standalone';
 import { NgFor } from '@angular/common';
 import { filter } from 'rxjs/operators';
@@ -14,7 +14,7 @@ import { filter } from 'rxjs/operators';
     </ion-breadcrumbs>
   `,
   standalone: true,
-  imports: [IonBreadcrumbs, IonBreadcrumb, NgFor],
+  imports: [IonBreadcrumbs, IonBreadcrumb, NgFor, RouterLink],
 })
 export class BreadcrumbsComponent {
   breadcrumbs: { label: string; url: string }[] = [];


### PR DESCRIPTION
## Summary
- add RouterLink to breadcrumb component imports

## Testing
- `npm run lint` *(fails: ng not found)*
- `npx ng lint` *(fails: 403 Forbidden due to no internet)*
- `npm test -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686040eba7288327bc09e46f3712e4d8