### PR TITLE
Fix menu routing and restore tab bar position

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -15,7 +15,7 @@ import {
   IonIcon,
   IonTitle,
 } from '@ionic/angular/standalone';
-import { Router } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { FirebaseService } from './services/firebase.service';
 import { RoleService } from './services/role.service';
 import { NgIf } from '@angular/common';
@@ -40,7 +40,8 @@ import { BreadcrumbsComponent } from './components/breadcrumbs.component';
     IonIcon,
     IonTitle,
     NgIf,
-    BreadcrumbsComponent
+    BreadcrumbsComponent,
+    RouterLink
   ],
 })
 export class AppComponent {

--- a/src/app/tabs/tabs.page.html
+++ b/src/app/tabs/tabs.page.html
@@ -17,6 +17,7 @@
 </ion-header>
 
 <ion-tabs>
+  <ion-router-outlet></ion-router-outlet>
 
   <ion-tab-bar slot="bottom">
     <ng-container *ngIf="role === 'parent'; else childTabs">

--- a/src/app/tabs/tabs.page.ts
+++ b/src/app/tabs/tabs.page.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {
   IonTabs,
+  IonRouterOutlet,
 
   IonTabBar,
   IonTabButton,
@@ -26,6 +27,7 @@ import { BreadcrumbsComponent } from '../components/breadcrumbs.component';
 
     CommonModule,
     IonTabs,
+    IonRouterOutlet,
     IonTabBar,
     IonTabButton,
     IonHeader,


### PR DESCRIPTION
## Summary
- import `RouterLink` in `AppComponent` so menu links work
- add missing `ion-router-outlet` to `TabsPage`
- include `IonRouterOutlet` in the standalone imports

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68604266861883279e7c2b020ebe5bc1