### PR TITLE
Refactor menu/header into tabs

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,42 +1,5 @@
 <ion-app>
-  <ion-menu contentId="main">
-    <ion-header>
-      <ion-toolbar>
-        <ion-title>Menu</ion-title>
-      </ion-toolbar>
-    </ion-header>
-    <ion-content>
-      <ion-list>
-        <ion-menu-toggle auto-hide="true">
-          <ion-item routerLink="/tabs/home">Home</ion-item>
-          <ion-item routerLink="/tabs/check-in">Daily Check-In</ion-item>
-          <ion-item routerLink="/tabs/bible-quiz">Bible Quiz</ion-item>
-          <ion-item routerLink="/tabs/essay-tracker">Essay Tracker</ion-item>
-          <ion-item routerLink="/tabs/project-tracker">Project Tracker</ion-item>
-          <ion-item routerLink="/tabs/leaderboard">Leaderboard</ion-item>
-        </ion-menu-toggle>
-      </ion-list>
-    </ion-content>
-  </ion-menu>
-
-  <div id="main">
-    <ion-header *ngIf="loggedIn">
-      <ion-toolbar>
-        <ion-buttons slot="start">
-          <ion-menu-button></ion-menu-button>
-          <ion-button routerLink="/tabs">
-            <ion-icon name="home-outline"></ion-icon>
-          </ion-button>
-        </ion-buttons>
-        <ion-title>Kids Faith Tracker</ion-title>
-        <ion-buttons slot="end">
-          <ion-button (click)="logout()">
-            <ion-icon name="log-out-outline"></ion-icon>
-          </ion-button>
-        </ion-buttons>
-      </ion-toolbar>
-      <app-breadcrumbs></app-breadcrumbs>
-    </ion-header>
+  <div>
     <ion-router-outlet></ion-router-outlet>
   </div>
 </ion-app>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,24 +2,10 @@ import { Component } from '@angular/core';
 import {
   IonApp,
   IonRouterOutlet,
-  IonHeader,
-  IonToolbar,
-  IonMenu,
-  IonContent,
-  IonList,
-  IonItem,
-  IonMenuToggle,
-  IonButtons,
-  IonMenuButton,
-  IonButton,
-  IonIcon,
-  IonTitle,
 } from '@ionic/angular/standalone';
-import { Router, RouterLink } from '@angular/router';
+import { Router } from '@angular/router';
 import { FirebaseService } from './services/firebase.service';
 import { RoleService } from './services/role.service';
-import { NgIf } from '@angular/common';
-import { BreadcrumbsComponent } from './components/breadcrumbs.component';
 
 @Component({
   selector: 'app-root',
@@ -27,21 +13,6 @@ import { BreadcrumbsComponent } from './components/breadcrumbs.component';
   imports: [
     IonApp,
     IonRouterOutlet,
-    IonMenu,
-    IonContent,
-    IonList,
-    IonItem,
-    IonMenuToggle,
-    IonHeader,
-    IonToolbar,
-    IonButtons,
-    IonMenuButton,
-    IonButton,
-    IonIcon,
-    IonTitle,
-    NgIf,
-    BreadcrumbsComponent,
-    RouterLink
   ],
 })
 export class AppComponent {

--- a/src/app/tabs/tabs.page.html
+++ b/src/app/tabs/tabs.page.html
@@ -1,23 +1,44 @@
-<ion-header>
-  <ion-toolbar>
-    <ion-buttons slot="start">
-      <ion-menu-button></ion-menu-button>
-      <ion-button routerLink="/tabs">
-        <ion-icon name="home-outline"></ion-icon>
-      </ion-button>
-    </ion-buttons>
-    <ion-title>Kids Faith Tracker</ion-title>
-    <ion-buttons slot="end">
-      <ion-button (click)="logout()">
-        <ion-icon name="log-out-outline"></ion-icon>
-      </ion-button>
-    </ion-buttons>
-  </ion-toolbar>
-  <app-breadcrumbs></app-breadcrumbs>
-</ion-header>
+<ion-menu contentId="main">
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Menu</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content>
+    <ion-list>
+      <ion-menu-toggle auto-hide="true">
+        <ion-item routerLink="/tabs/home">Home</ion-item>
+        <ion-item routerLink="/tabs/check-in">Daily Check-In</ion-item>
+        <ion-item routerLink="/tabs/bible-quiz">Bible Quiz</ion-item>
+        <ion-item routerLink="/tabs/essay-tracker">Essay Tracker</ion-item>
+        <ion-item routerLink="/tabs/project-tracker">Project Tracker</ion-item>
+        <ion-item routerLink="/tabs/leaderboard">Leaderboard</ion-item>
+      </ion-menu-toggle>
+    </ion-list>
+  </ion-content>
+</ion-menu>
 
-<ion-tabs>
-  <ion-router-outlet></ion-router-outlet>
+<div id="main">
+  <ion-header>
+    <ion-toolbar>
+      <ion-buttons slot="start">
+        <ion-menu-button></ion-menu-button>
+        <ion-button routerLink="/tabs">
+          <ion-icon name="home-outline"></ion-icon>
+        </ion-button>
+      </ion-buttons>
+      <ion-title>Kids Faith Tracker</ion-title>
+      <ion-buttons slot="end">
+        <ion-button (click)="logout()">
+          <ion-icon name="log-out-outline"></ion-icon>
+        </ion-button>
+      </ion-buttons>
+    </ion-toolbar>
+    <app-breadcrumbs></app-breadcrumbs>
+  </ion-header>
+
+  <ion-tabs>
+    <ion-router-outlet></ion-router-outlet>
 
   <ion-tab-bar slot="bottom">
     <ng-container *ngIf="role === 'parent'; else childTabs">
@@ -62,3 +83,5 @@
   </ion-tab-bar>
 
 </ion-tabs>
+
+</div>

--- a/src/app/tabs/tabs.page.ts
+++ b/src/app/tabs/tabs.page.ts
@@ -1,9 +1,9 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
 import {
   IonTabs,
   IonRouterOutlet,
-
   IonTabBar,
   IonTabButton,
   IonHeader,
@@ -14,6 +14,11 @@ import {
   IonButton,
   IonIcon,
   IonLabel,
+  IonMenu,
+  IonContent,
+  IonList,
+  IonItem,
+  IonMenuToggle,
 } from '@ionic/angular/standalone';
 
 import { RoleService } from '../services/role.service';
@@ -38,7 +43,13 @@ import { BreadcrumbsComponent } from '../components/breadcrumbs.component';
     IonButton,
     IonIcon,
     IonLabel,
+    IonMenu,
+    IonContent,
+    IonList,
+    IonItem,
+    IonMenuToggle,
     BreadcrumbsComponent,
+    RouterLink,
   ],
   templateUrl: './tabs.page.html',
   styleUrls: ['./tabs.page.scss'],


### PR DESCRIPTION
## Summary
- simplify `AppComponent` layout and imports
- move menu and header to `TabsPage`
- update `TabsPage` imports for menu and routing

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686044b252c88327891395a46f265040