### PR TITLE
Fix events disabled by zone flag

### DIFF
--- a/src/zone-flags.ts
+++ b/src/zone-flags.ts
@@ -3,4 +3,6 @@
  * running with certain Web Component callbacks
  */
 // eslint-disable-next-line no-underscore-dangle
-(window as any).__Zone_disable_customElements = true;
+// Disabling this flag prevents Ionic components from emitting events that
+// Angular can listen to. Commented out so form elements remain interactive.
+// (window as any).__Zone_disable_customElements = true;


### PR DESCRIPTION
## Summary
- disable custom element flag in zone to ensure Ionic events emit properly

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860967f08588327b40f9556efa6e659