### PR TITLE
Fix global styles blocking user interactions

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -46,9 +46,3 @@ ion-tab-bar {
   --color: var(--ion-color-dark);
   --color-selected: var(--ion-color-primary);
 }
-ion-page,
-ion-content {
-  display: block;
-  width: 100%;
-  height: 100%;
-}


### PR DESCRIPTION
## Summary
- remove custom `ion-page` and `ion-content` CSS overrides

Removing these overrides restores Ionic's default layout behavior and allows pages to scroll and respond to taps again.

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68609af3f4b88327ae9adb0917791a56