### PR TITLE
Revert icon registration change

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -29,15 +29,15 @@ import { routes } from './app/app.routes';
 import { AppComponent } from './app/app.component';
 
 addIcons({
-  'calendar-outline': calendarOutline,
-  'help-outline': helpOutline,
-  'create-outline': createOutline,
-  'list-outline': listOutline,
-  'home-outline': homeOutline,
-  'log-out-outline': logOutOutline,
-  'person-add-outline': personAddOutline,
-  'trophy-outline': trophyOutline,
-  'time-outline': timeOutline,
+  calendarOutline,
+  helpOutline,
+  createOutline,
+  listOutline,
+  homeOutline,
+  logOutOutline,
+  personAddOutline,
+  trophyOutline,
+  timeOutline,
 });
 
 bootstrapApplication(AppComponent, {


### PR DESCRIPTION
## Summary
- revert icon registration names

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68609c461c588327afffb1b0373f1c38