### PR TITLE
Remove ion-page class from page templates

### DIFF
--- a/src/app/academic-progress/academic-progress.page.html
+++ b/src/app/academic-progress/academic-progress.page.html
@@ -1,5 +1,5 @@
 
-<div class="ion-page">
+<div>
   <ion-header>
     <ion-toolbar>
       <ion-title>Academic Progress</ion-title>

--- a/src/app/bible-quiz/bible-quiz.page.html
+++ b/src/app/bible-quiz/bible-quiz.page.html
@@ -1,5 +1,5 @@
 
-<div class="ion-page">
+<div>
   <ion-header>
     <ion-toolbar>
       <ion-title>Bible Quiz</ion-title>

--- a/src/app/check-in/check-in.page.html
+++ b/src/app/check-in/check-in.page.html
@@ -1,5 +1,5 @@
 
-<div class="ion-page">
+<div>
   <ion-header>
     <ion-toolbar>
       <ion-title>Daily Check-In</ion-title>

--- a/src/app/child-account/child-account.page.html
+++ b/src/app/child-account/child-account.page.html
@@ -1,5 +1,5 @@
 
-<div class="ion-page">
+<div>
   <ion-header>
     <ion-toolbar>
       <ion-title>Create Child Account</ion-title>

--- a/src/app/essay-tracker/essay-tracker.page.html
+++ b/src/app/essay-tracker/essay-tracker.page.html
@@ -1,5 +1,5 @@
 
-<div class="ion-page">
+<div>
   <ion-header>
     <ion-toolbar>
       <ion-title>Essay Tracker</ion-title>

--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -1,4 +1,4 @@
-<div class="ion-page">
+<div>
   <ion-header [translucent]="true">
     <ion-toolbar>
       <ion-title>

--- a/src/app/leaderboard/leaderboard.page.html
+++ b/src/app/leaderboard/leaderboard.page.html
@@ -1,5 +1,5 @@
 
-<div class="ion-page">
+<div>
   <ion-header>
     <ion-toolbar>
       <ion-title>Leaderboard</ion-title>

--- a/src/app/login/login.page.html
+++ b/src/app/login/login.page.html
@@ -1,5 +1,5 @@
 
-<div class="ion-page">
+<div>
   <ion-header>
     <ion-toolbar>
       <ion-title>Login</ion-title>

--- a/src/app/mental-status/mental-status.page.html
+++ b/src/app/mental-status/mental-status.page.html
@@ -1,5 +1,5 @@
 
-<div class="ion-page">
+<div>
   <ion-header>
     <ion-toolbar>
       <ion-title>Mental & Emotional Status</ion-title>

--- a/src/app/project-tracker/project-tracker.page.html
+++ b/src/app/project-tracker/project-tracker.page.html
@@ -1,4 +1,4 @@
-<div class="ion-page">
+<div>
   <ion-header>
     <ion-toolbar>
       <ion-title>Project Tracker</ion-title>

--- a/src/app/quiz-history/quiz-history.page.html
+++ b/src/app/quiz-history/quiz-history.page.html
@@ -1,4 +1,4 @@
-<div class="ion-page">
+<div>
 <ion-header>
   <ion-toolbar>
     <ion-title>Quiz History</ion-title>

--- a/src/app/register/register.page.html
+++ b/src/app/register/register.page.html
@@ -1,5 +1,5 @@
 
-<div class="ion-page">
+<div>
   <ion-header>
     <ion-toolbar>
       <ion-title>Register</ion-title>


### PR DESCRIPTION
## Summary
- remove the `ion-page` class from each page template

## Testing
- `npm test --silent -- --no-watch --no-progress` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860a78b68608327b8388ca3c9bbd881