### PR TITLE
Add toast notifications

### DIFF
--- a/src/app/academic-progress/academic-progress.page.ts
+++ b/src/app/academic-progress/academic-progress.page.ts
@@ -15,6 +15,7 @@ import {
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { AcademicProgressEntry } from '../models/academic-progress';
+import { ToastController } from '@ionic/angular';
 
 @Component({
   selector: 'app-academic-progress',
@@ -44,7 +45,7 @@ export class AcademicProgressPage {
     needsHelp: false,
   };
 
-  constructor(private fb: FirebaseService) {}
+  constructor(private fb: FirebaseService, private toastCtrl: ToastController) {}
 
   async submit() {
     const user = this.fb.auth.currentUser;
@@ -53,6 +54,11 @@ export class AcademicProgressPage {
       childId: user ? user.uid : null,
       date: new Date().toISOString(),
     });
-    console.log('Academic progress saved');
+    const toast = await this.toastCtrl.create({
+      message: 'Academic progress saved',
+      duration: 1500,
+      position: 'bottom',
+    });
+    await toast.present();
   }
 }

--- a/src/app/bible-quiz/bible-quiz.page.ts
+++ b/src/app/bible-quiz/bible-quiz.page.ts
@@ -17,6 +17,7 @@ import {
 } from '@ionic/angular/standalone';
 import { BibleQuizApiService } from '../services/bible-quiz-api.service';
 import { BibleQuestion } from '../models/bible-quiz';
+import { ToastController } from '@ionic/angular';
 
 @Component({
   selector: 'app-bible-quiz',
@@ -45,7 +46,7 @@ export class BibleQuizPage implements OnInit {
   answer = '';
   loading = false;
 
-  constructor(private api: BibleQuizApiService) {}
+  constructor(private api: BibleQuizApiService, private toastCtrl: ToastController) {}
 
   ngOnInit() {
     this.loadQuiz();
@@ -71,8 +72,13 @@ export class BibleQuizPage implements OnInit {
     }
     this.api
       .submitQuiz({ question: this.question, answer: this.answer })
-      .subscribe(() => {
-        console.log('Quiz submitted');
+      .subscribe(async () => {
+        const toast = await this.toastCtrl.create({
+          message: 'Quiz submitted',
+          duration: 1500,
+          position: 'bottom',
+        });
+        await toast.present();
       });
   }
 }

--- a/src/app/check-in/check-in.page.ts
+++ b/src/app/check-in/check-in.page.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import {  IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonTextarea, IonSegment, IonSegmentButton, IonCheckbox } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
+import { ToastController } from '@ionic/angular';
 import { DailyCheckin } from '../models/daily-checkin';
 
 @Component({
@@ -44,7 +45,7 @@ export class CheckInPage {
     helpRequest: '',
   };
 
-  constructor(private fbService: FirebaseService) {}
+  constructor(private fbService: FirebaseService, private toastCtrl: ToastController) {}
 
   async submit() {
     const user = this.fbService.auth.currentUser;
@@ -55,6 +56,11 @@ export class CheckInPage {
       parentId,
       date: new Date().toISOString(),
     });
-    console.log('Check-in saved');
+    const toast = await this.toastCtrl.create({
+      message: 'Check-in saved',
+      duration: 1500,
+      position: 'bottom',
+    });
+    await toast.present();
   }
 }

--- a/src/app/child-account/child-account.page.ts
+++ b/src/app/child-account/child-account.page.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
+import { ToastController } from '@ionic/angular';
 
 @Component({
   selector: 'app-child-account',
@@ -27,7 +28,11 @@ import { Router } from '@angular/router';
 export class ChildAccountPage {
   form = { email: '', password: '', age: null as number | null };
 
-  constructor(private fb: FirebaseService, private router: Router) {}
+  constructor(
+    private fb: FirebaseService,
+    private router: Router,
+    private toastCtrl: ToastController
+  ) {}
 
   async create() {
     const user = this.fb.auth.currentUser;
@@ -43,6 +48,12 @@ export class ChildAccountPage {
       user.uid,
       this.form.age
     );
+    const toast = await this.toastCtrl.create({
+      message: 'Child account created',
+      duration: 1500,
+      position: 'bottom',
+    });
+    await toast.present();
     this.router.navigateByUrl('/tabs/home');
   }
 }

--- a/src/app/essay-tracker/essay-tracker.page.ts
+++ b/src/app/essay-tracker/essay-tracker.page.ts
@@ -18,6 +18,7 @@ import {
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { EssayEntry } from '../models/essay-entry';
+import { ToastController } from '@ionic/angular';
 
 @Component({
   selector: 'app-essay-tracker',
@@ -49,7 +50,7 @@ export class EssayTrackerPage {
     needHelp: false,
   };
 
-  constructor(private fb: FirebaseService) {}
+  constructor(private fb: FirebaseService, private toastCtrl: ToastController) {}
 
   async submit() {
     const user = this.fb.auth.currentUser;
@@ -58,6 +59,11 @@ export class EssayTrackerPage {
       childId: user ? user.uid : null,
       date: new Date().toISOString(),
     });
-    console.log('Essay saved');
+    const toast = await this.toastCtrl.create({
+      message: 'Essay saved',
+      duration: 1500,
+      position: 'bottom',
+    });
+    await toast.present();
   }
 }

--- a/src/app/login/login.page.ts
+++ b/src/app/login/login.page.ts
@@ -6,6 +6,7 @@ import { RouterLink } from '@angular/router';
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
 import { RoleService } from '../services/role.service';
+import { ToastController } from '@ionic/angular';
 
 @Component({
   selector: 'app-login',
@@ -39,18 +40,31 @@ export class LoginPage {
   constructor(
     private fb: FirebaseService,
     private router: Router,
-    private roleSvc: RoleService
+    private roleSvc: RoleService,
+    private toastCtrl: ToastController
   ) {}
 
   async login() {
     await this.fb.login(this.form.email, this.form.password);
     this.roleSvc.setRole(this.selectedRole);
+    const toast = await this.toastCtrl.create({
+      message: 'Logged in',
+      duration: 1500,
+      position: 'bottom',
+    });
+    await toast.present();
     this.router.navigateByUrl('/tabs');
   }
 
   async loginWithGoogle() {
     await this.fb.loginWithGoogle();
     this.roleSvc.setRole(this.selectedRole);
+    const toast = await this.toastCtrl.create({
+      message: 'Logged in with Google',
+      duration: 1500,
+      position: 'bottom',
+    });
+    await toast.present();
     this.router.navigateByUrl('/tabs');
   }
 }

--- a/src/app/mental-status/mental-status.page.ts
+++ b/src/app/mental-status/mental-status.page.ts
@@ -17,6 +17,7 @@ import {
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { MentalStatus } from '../models/mental-status';
+import { ToastController } from '@ionic/angular';
 
 @Component({
   selector: 'app-mental-status',
@@ -49,7 +50,7 @@ export class MentalStatusPage {
     suggestions: '',
   };
 
-  constructor(private fb: FirebaseService) {}
+  constructor(private fb: FirebaseService, private toastCtrl: ToastController) {}
 
   async submit() {
     const user = this.fb.auth.currentUser;
@@ -60,6 +61,11 @@ export class MentalStatusPage {
       parentId,
       date: new Date().toISOString(),
     });
-    console.log('Mental status saved');
+    const toast = await this.toastCtrl.create({
+      message: 'Mental status saved',
+      duration: 1500,
+      position: 'bottom',
+    });
+    await toast.present();
   }
 }

--- a/src/app/project-tracker/project-tracker.page.ts
+++ b/src/app/project-tracker/project-tracker.page.ts
@@ -18,6 +18,7 @@ import {
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { ProjectEntry } from '../models/project-entry';
+import { ToastController } from '@ionic/angular';
 
 @Component({
   selector: 'app-project-tracker',
@@ -54,7 +55,7 @@ export class ProjectTrackerPage {
     progress: 'in progress',
   };
 
-  constructor(private fb: FirebaseService) {}
+  constructor(private fb: FirebaseService, private toastCtrl: ToastController) {}
 
   async submit() {
     if (!this.form.title || !this.form.presentationDate || !this.form.enjoyment) {
@@ -69,7 +70,12 @@ export class ProjectTrackerPage {
       childId: user ? user.uid : null,
       date: new Date().toISOString(),
     });
-    console.log('Project saved');
+    const toast = await this.toastCtrl.create({
+      message: 'Project saved',
+      duration: 1500,
+      position: 'bottom',
+    });
+    await toast.present();
     this.form = {
       title: '',
       presentationDate: '',

--- a/src/app/register/register.page.ts
+++ b/src/app/register/register.page.ts
@@ -5,6 +5,7 @@ import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabe
 import { RouterLink } from '@angular/router';
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
+import { ToastController } from '@ionic/angular';
 
 @Component({
   selector: 'app-register',
@@ -30,15 +31,31 @@ import { Router } from '@angular/router';
 export class RegisterPage {
   form = { email: '', password: '' };
 
-  constructor(private fb: FirebaseService, private router: Router) {}
+  constructor(
+    private fb: FirebaseService,
+    private router: Router,
+    private toastCtrl: ToastController
+  ) {}
 
   async register() {
     await this.fb.register(this.form.email, this.form.password);
+    const toast = await this.toastCtrl.create({
+      message: 'Registration successful',
+      duration: 1500,
+      position: 'bottom',
+    });
+    await toast.present();
     this.router.navigateByUrl('/login');
   }
 
   async registerWithGoogle() {
     await this.fb.loginWithGoogle();
+    const toast = await this.toastCtrl.create({
+      message: 'Registered with Google',
+      duration: 1500,
+      position: 'bottom',
+    });
+    await toast.present();
     this.router.navigateByUrl('/login');
   }
 }


### PR DESCRIPTION
## Summary
- show toast messages after user actions like login, registration, submissions, etc.

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860c6fe1e588327b09843e98b503e69