### PR TITLE
Fix home icon navigation

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -2,7 +2,7 @@
   <ion-header *ngIf="loggedIn">
     <ion-toolbar>
       <ion-buttons slot="start">
-        <ion-button routerLink="/tabs">
+        <ion-button routerLink="/tabs/home">
           <ion-icon name="home-outline"></ion-icon>
         </ion-button>
       </ion-buttons>


### PR DESCRIPTION
## Summary
- ensure the header's home icon routes directly to the home tab

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860cc1c84e483278a6ca5bf7dd151a1