### PR TITLE
Fix initial page title flicker

### DIFF
--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -1,7 +1,7 @@
   <ion-header [translucent]="true">
     <ion-toolbar>
       <ion-title>
-        Kids Faith Trackerrr
+        Kids Faith Tracker
       </ion-title>
     </ion-toolbar>
   </ion-header>

--- a/src/app/tabs/tabs.page.ts
+++ b/src/app/tabs/tabs.page.ts
@@ -55,6 +55,13 @@ export class TabsPage {
       }
     });
 
+    // Initialize page title based on the current active route
+    let initialChild = this.route.firstChild;
+    while (initialChild?.firstChild) {
+      initialChild = initialChild.firstChild;
+    }
+    this.pageTitle = initialChild?.snapshot.data['title'] || 'Kids Faith Tracker';
+
     this.router.events
       .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd))
       .subscribe(() => {


### PR DESCRIPTION
## Summary
- initialize `TabsPage` title from current route to avoid title flicker
- fix typo in Home page title

## Testing
- `npm test --silent` *(fails: ng not found)*
- `npm run lint --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860e8d86c5483278dcaea266c09881d