### PR TITLE
Handle login errors and update firebase setup docs

### DIFF
--- a/docs/firebase-setup.md
+++ b/docs/firebase-setup.md
@@ -29,3 +29,13 @@ Copy these files into your Firebase project and deploy them using the Firebase C
 firebase deploy --only firestore:rules
 firebase deploy --only firestore:indexes
 ```
+
+## Authorized Domains
+
+If the application is hosted on a custom domain (for example
+`kidsfaithtracker.netlify.app`), that domain must be added to the **Authorized
+domains** list in the Firebase console. Navigate to **Authentication →
+Settings** in your Firebase project and add the domain under "Authorized
+domains". Without this step OAuth-based sign in (such as Google login) will
+fail and pages that rely on the authenticated user—like the quiz history—will
+appear empty.

--- a/src/app/login/login.page.ts
+++ b/src/app/login/login.page.ts
@@ -45,26 +45,46 @@ export class LoginPage {
   ) {}
 
   async login() {
-    await this.fb.login(this.form.email, this.form.password);
-    this.roleSvc.setRole(this.selectedRole);
-    const toast = await this.toastCtrl.create({
-      message: 'Logged in',
-      duration: 1500,
-      position: 'bottom',
-    });
-    await toast.present();
-    this.router.navigateByUrl('/tabs');
+    try {
+      await this.fb.login(this.form.email, this.form.password);
+      this.roleSvc.setRole(this.selectedRole);
+      const toast = await this.toastCtrl.create({
+        message: 'Logged in',
+        duration: 1500,
+        position: 'bottom',
+      });
+      await toast.present();
+      this.router.navigateByUrl('/tabs');
+    } catch (err: any) {
+      const toast = await this.toastCtrl.create({
+        message: err?.message || 'Login failed',
+        duration: 1500,
+        position: 'bottom',
+        color: 'danger',
+      });
+      await toast.present();
+    }
   }
 
   async loginWithGoogle() {
-    await this.fb.loginWithGoogle();
-    this.roleSvc.setRole(this.selectedRole);
-    const toast = await this.toastCtrl.create({
-      message: 'Logged in with Google',
-      duration: 1500,
-      position: 'bottom',
-    });
-    await toast.present();
-    this.router.navigateByUrl('/tabs');
+    try {
+      await this.fb.loginWithGoogle();
+      this.roleSvc.setRole(this.selectedRole);
+      const toast = await this.toastCtrl.create({
+        message: 'Logged in with Google',
+        duration: 1500,
+        position: 'bottom',
+      });
+      await toast.present();
+      this.router.navigateByUrl('/tabs');
+    } catch (err: any) {
+      const toast = await this.toastCtrl.create({
+        message: err?.message || 'Google login failed',
+        duration: 1500,
+        position: 'bottom',
+        color: 'danger',
+      });
+      await toast.present();
+    }
   }
 }


### PR DESCRIPTION
## Summary
- update docs with instructions for configuring authorized domains in Firebase
- show toast notification if login or Google login fails

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861489d8dc08327b25f1717cadf8b86