### PR TITLE
Restore /api prefix for quiz endpoints

### DIFF
--- a/src/app/services/bible-quiz-api.service.ts
+++ b/src/app/services/bible-quiz-api.service.ts
@@ -24,7 +24,7 @@ export class BibleQuizApiService {
     }
 
     return this.http
-      .get<BibleQuestion>(`${environment.apiUrl}/quizzes/today`)
+      .get<BibleQuestion>(`${environment.apiUrl}/api/quizzes/today`)
       .pipe(
         timeout(5000),
         catchError(() =>
@@ -55,7 +55,7 @@ export class BibleQuizApiService {
       answers: [data.answer],
     };
     return this.http
-      .post(`${environment.apiUrl}/quizzes/submit`, payload)
+      .post(`${environment.apiUrl}/api/quizzes/submit`, payload)
       .pipe(
         timeout(5000),
         catchError(() => {
@@ -77,7 +77,7 @@ export class BibleQuizApiService {
     }
 
     return this.http
-      .get<BibleQuizResult[]>(`${environment.apiUrl}/quizzes/${childId}/history`)
+      .get<BibleQuizResult[]>(`${environment.apiUrl}/api/quizzes/${childId}/history`)
       .pipe(
         timeout(5000),
         catchError(() => from(this.fb.getBibleQuizHistory(childId)))


### PR DESCRIPTION
## Summary
- fix quiz API paths by adding the `/api` prefix again

## Testing
- `npm test --silent` *(fails: ng not found)*
- `npm run lint --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68614b1507688327987c6386575401fc