### PR TITLE
Refresh quiz history on each login

### DIFF
--- a/src/app/quiz-history/quiz-history.page.ts
+++ b/src/app/quiz-history/quiz-history.page.ts
@@ -39,11 +39,20 @@ export class QuizHistoryPage implements OnInit {
   ) {}
 
   async ngOnInit() {
+    await this.loadHistory();
+  }
+
+  async ionViewWillEnter() {
+    await this.loadHistory();
+  }
+
+  private async loadHistory() {
     const user = this.fb.auth.currentUser;
     if (!user) {
+      this.results = [];
       return;
     }
     this.results = await firstValueFrom(this.api.getHistory(user.uid));
-    console.log('History:', this.results)
+    console.log('History:', this.results);
   }
 }


### PR DESCRIPTION
## Summary
- ensure quiz history is refreshed any time the page becomes active

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68614e6eaf8c8327b514313a70f63478