### PR TITLE
Improve MentorApiService types and error handling

### DIFF
--- a/src/app/models/mentor-assignment.ts
+++ b/src/app/models/mentor-assignment.ts
@@ -1,0 +1,8 @@
+export interface MentorAssignment {
+  mentorId: string;
+  childId: string;
+}
+
+export interface MentorChildren {
+  children: string[];
+}

--- a/src/app/services/mentor-api.service.ts
+++ b/src/app/services/mentor-api.service.ts
@@ -4,32 +4,44 @@ import { Observable, from } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { environment } from '../../environments/environment';
 import { FirebaseService } from './firebase.service';
+import { MentorAssignment, MentorChildren } from '../models/mentor-assignment';
 
 @Injectable({ providedIn: 'root' })
 export class MentorApiService {
+  private apiEnabled = !!environment.apiUrl;
+  private readonly baseUrl = `${environment.apiUrl}/api/mentors`;
+
   constructor(private http: HttpClient, private fb: FirebaseService) {}
 
-  assignMentor(data: { mentorId: string; childId: string }): Observable<unknown> {
-    return this.http
-      .post(`${environment.apiUrl}/api/mentors/assign`, data)
-      .pipe(
-        catchError(() =>
-          from(this.fb.assignMentor(data.mentorId, data.childId))
-        )
-      );
+  assignMentor(data: MentorAssignment): Observable<unknown> {
+    if (!this.apiEnabled) {
+      return from(this.fb.assignMentor(data.mentorId, data.childId));
+    }
+
+    return this.http.post(`${this.baseUrl}/assign`, data).pipe(
+      catchError((err) => {
+        console.error('Failed to assign mentor via API, falling back', err);
+        return from(this.fb.assignMentor(data.mentorId, data.childId));
+      })
+    );
   }
 
-  getChildren(mentorId: string): Observable<{ children: string[] }> {
+  getChildren(mentorId: string): Observable<MentorChildren> {
+    if (!this.apiEnabled) {
+      return from(this.fb.getChildForMentor(mentorId)).pipe(
+        map((children) => ({ children }))
+      );
+    }
+
     return this.http
-      .get<{ children: string[] }>(
-        `${environment.apiUrl}/api/mentors/${mentorId}/children`
-      )
+      .get<MentorChildren>(`${this.baseUrl}/${mentorId}/children`)
       .pipe(
-        catchError(() =>
-          from(this.fb.getChildForMentor(mentorId)).pipe(
+        catchError((err) => {
+          console.error('Failed to fetch mentor children via API, falling back', err);
+          return from(this.fb.getChildForMentor(mentorId)).pipe(
             map((children) => ({ children }))
-          )
-        )
+          );
+        })
       );
   }
 }


### PR DESCRIPTION
## Summary
- define MentorAssignment and MentorChildren interfaces
- refactor MentorApiService to use new interfaces
- add API enable flag and base URL
- log errors when falling back to Firebase

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68616463b23483279601013cd8e7ca2c