### PR TITLE
Fix leaderboard permission issue

### DIFF
--- a/docs/firebase-setup.md
+++ b/docs/firebase-setup.md
@@ -12,12 +12,13 @@ This document describes the Firestore collections and provides basic security ru
 - **schoolWork** – academic progress entries. Store `childId`, `parentId` and `timestamp`.
 - **projects** – project tracker entries. Store `childId`, `parentId` and `timestamp`.
 - **bibleQuestions** – pool of quiz questions. No user‑specific fields required.
+- **userStats** – points and streak information used for the leaderboard. Document ID matches the child's UID.
 
 Every document that references a child should include `childId` and `parentId`. This allows security rules to verify ownership.
 
 ## Security Rules
 
-A set of sample Firestore rules is provided in `firebase/firestore.rules`. These rules grant each parent read access to their child’s documents while allowing the child to create and read their own data.
+A set of sample Firestore rules is provided in `firebase/firestore.rules`. These rules grant each parent read access to their child’s documents while allowing the child to create and read their own data. The `userStats` collection, used for the leaderboard, is readable by any authenticated user while write access is limited to the child’s UID.
 
 ## Indexes
 

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -55,5 +55,13 @@ service cloud.firestore {
       allow read: if request.auth != null;
       allow write: if false;
     }
+
+    match /userStats/{userId} {
+      // Any authenticated user can read leaderboard data
+      allow read: if request.auth != null;
+      // Only the child account may update their stats
+      allow create, update: if request.auth != null && request.auth.uid == userId;
+      allow delete: if false;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- update Firestore rules to allow authenticated users to read `userStats`
- document the `userStats` collection and updated security rules

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68616636192c83279de894815753470e