### PR TITLE
Implement daily 5-question quiz

### DIFF
--- a/src/app/bible-quiz/bible-quiz.page.html
+++ b/src/app/bible-quiz/bible-quiz.page.html
@@ -7,24 +7,24 @@
 
   <ion-content>
   <ion-spinner *ngIf="loading" name="dots" class="center-spinner"></ion-spinner>
-  <ion-list *ngIf="!loading && question">
+  <ion-list *ngIf="!loading && currentQuestion">
     <ion-item>
-      <ion-label position="stacked">Question</ion-label>
-      <ion-label>{{ question.text || question.question }}</ion-label>
+      <ion-label position="stacked">Question {{ currentIndex + 1 }} of {{ questions.length }}</ion-label>
+      <ion-label>{{ currentQuestion.text || currentQuestion.question }}</ion-label>
     </ion-item>
-    <ion-radio-group [(ngModel)]="answer" *ngIf="question.options?.length">
-      <ion-item *ngFor="let opt of question.options">
+    <ion-radio-group [(ngModel)]="answer" *ngIf="currentQuestion.options?.length">
+      <ion-item *ngFor="let opt of currentQuestion.options">
         <ion-label>{{ opt }}</ion-label>
         <ion-radio slot="start" [value]="opt"></ion-radio>
       </ion-item>
     </ion-radio-group>
-    <ion-item *ngIf="!question.options?.length">
+    <ion-item *ngIf="!currentQuestion.options?.length">
       <ion-label position="stacked">Your Answer</ion-label>
       <ion-input [(ngModel)]="answer"></ion-input>
     </ion-item>
   </ion-list>
   <div class="ion-padding">
-    <ion-button expand="block" (click)="submit()">Submit</ion-button>
+    <ion-button expand="block" (click)="submit()" [disabled]="!currentQuestion">Submit</ion-button>
   </div>
   </ion-content>
 

--- a/src/app/services/bible-quiz-api.service.ts
+++ b/src/app/services/bible-quiz-api.service.ts
@@ -16,20 +16,22 @@ export class BibleQuizApiService {
   /**
   * All quiz related endpoints are served directly under the backend base URL.
   */
-  getTodayQuiz(): Observable<BibleQuestion> {
+  getTodayQuizzes(count = 5): Observable<BibleQuestion[]> {
     if (!this.apiEnabled) {
-      return from(this.fb.getRandomBibleQuestion()).pipe(
-        map((q) => q as BibleQuestion)
+      return from(this.fb.getRandomBibleQuestions(count)).pipe(
+        map((q) => q as BibleQuestion[])
       );
     }
 
     return this.http
-      .get<BibleQuestion>(`${environment.apiUrl}/api/quizzes/today`)
+      .get<BibleQuestion[]>(
+        `${environment.apiUrl}/api/quizzes/today?count=${count}`
+      )
       .pipe(
         timeout(5000),
         catchError(() =>
-          from(this.fb.getRandomBibleQuestion()).pipe(
-            map((q) => q as BibleQuestion)
+          from(this.fb.getRandomBibleQuestions(count)).pipe(
+            map((q) => q as BibleQuestion[])
           )
         )
       );

--- a/src/app/services/firebase.service.ts
+++ b/src/app/services/firebase.service.ts
@@ -144,6 +144,19 @@ export class FirebaseService {
     } as BibleQuestion;
   }
 
+  async getRandomBibleQuestions(count: number): Promise<BibleQuestion[]> {
+    const snap = await getDocs(collection(this.db, 'bibleQuestions'));
+    const docs = snap.docs;
+    if (docs.length === 0) {
+      return [];
+    }
+    const shuffled = docs.sort(() => 0.5 - Math.random());
+    return shuffled.slice(0, count).map((d) => ({
+      id: d.id,
+      ...(d.data() as Omit<BibleQuestion, 'id'>),
+    })) as BibleQuestion[];
+  }
+
   async getBibleQuizHistory(childId: string): Promise<BibleQuizResult[]> {
     const q = query(
       collection(this.db, 'bibleQuizzes'),

--- a/todo.md
+++ b/todo.md
@@ -29,6 +29,7 @@
 ## 📖 Bible Quiz Module
 - [x] Quiz prompt (daily)
 - [x] Randomize from DB question pool
+- [x] Limit to five questions per day
 - [x] Score submission + 200 points
 - [x] Save to `/bibleQuizzes`
 


### PR DESCRIPTION
## Summary
- support fetching multiple Bible quiz questions
- add helper to get multiple random questions from Firebase
- cycle through 5 questions per day in Bible Quiz page
- document daily question limit

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861928f6184832794f021a80f70760a