### PR TITLE
Implement multi-step Bible quiz

### DIFF
--- a/src/app/bible-quiz/bible-quiz.page.html
+++ b/src/app/bible-quiz/bible-quiz.page.html
@@ -12,7 +12,7 @@
       <ion-label position="stacked">Question {{ currentIndex + 1 }} of {{ questions.length }}</ion-label>
       <ion-label>{{ currentQuestion.text || currentQuestion.question }}</ion-label>
     </ion-item>
-    <ion-radio-group [(ngModel)]="answer" *ngIf="currentQuestion.options?.length">
+    <ion-radio-group [(ngModel)]="answers[currentIndex]" *ngIf="currentQuestion.options?.length">
       <ion-item *ngFor="let opt of currentQuestion.options">
         <ion-label>{{ opt }}</ion-label>
         <ion-radio slot="start" [value]="opt"></ion-radio>
@@ -20,11 +20,16 @@
     </ion-radio-group>
     <ion-item *ngIf="!currentQuestion.options?.length">
       <ion-label position="stacked">Your Answer</ion-label>
-      <ion-input [(ngModel)]="answer"></ion-input>
+      <ion-input [(ngModel)]="answers[currentIndex]"></ion-input>
+    </ion-item>
+    <ion-item *ngIf="currentQuestion.reference">
+      <ion-label class="reference">{{ currentQuestion.reference }}</ion-label>
     </ion-item>
   </ion-list>
-  <div class="ion-padding">
-    <ion-button expand="block" (click)="submit()" [disabled]="!currentQuestion">Submit</ion-button>
+  <div class="ion-padding navigation-buttons">
+    <ion-button (click)="prevQuestion()" [disabled]="currentIndex === 0">Back</ion-button>
+    <ion-button *ngIf="currentIndex < questions.length - 1" (click)="nextQuestion()" [disabled]="!answers[currentIndex]">Next</ion-button>
+    <ion-button *ngIf="currentIndex === questions.length - 1" (click)="submitAll()" [disabled]="!allAnswered()">Submit</ion-button>
   </div>
   </ion-content>
 

--- a/src/app/bible-quiz/bible-quiz.page.scss
+++ b/src/app/bible-quiz/bible-quiz.page.scss
@@ -3,3 +3,13 @@ ion-spinner.center-spinner {
   justify-content: center;
   margin-top: 2rem;
 }
+
+.reference {
+  color: var(--ion-color-secondary);
+  font-style: italic;
+}
+
+.navigation-buttons {
+  display: flex;
+  justify-content: space-between;
+}


### PR DESCRIPTION
## Summary
- update Bible quiz page to keep answers and navigate forward/backward
- allow submitting all answers together
- show reference text below each question in secondary colour
- add basic styling for reference text and navigation buttons

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686194f895b88327bf5810e1d086b90a