### PR TITLE
Fix radio visibility in quiz

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -46,3 +46,9 @@ ion-tab-bar {
   --color: var(--ion-color-dark);
   --color-selected: var(--ion-color-primary);
 }
+
+ion-radio,
+ion-checkbox {
+  --color: var(--ion-color-dark);
+  --color-checked: var(--ion-color-primary);
+}


### PR DESCRIPTION
## Summary
- tweak global styles so quiz options show clearly

## Testing
- `npm test --silent` *(fails: `ng: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686199eaa45c8327ba9d473f462ff0c8