### PR TITLE
Enhance quiz history listing

### DIFF
--- a/src/app/quiz-history/quiz-history.page.html
+++ b/src/app/quiz-history/quiz-history.page.html
@@ -5,8 +5,28 @@
 </ion-header>
 
 <ion-content>
-  <ion-list>
-    <ion-item *ngFor="let r of results">
+  <div class="ion-padding">
+    <h2>Total Score: {{ totalScore }}</h2>
+  </div>
+
+  <ion-list *ngIf="correctResults.length">
+    <ion-item lines="full">
+      <ion-label><strong>Correct Answers</strong></ion-label>
+    </ion-item>
+    <ion-item *ngFor="let r of correctResults">
+      <ion-label>
+        <h2>{{ r.question.text || r.question.question }}</h2>
+        <p>Your Answer: {{ r.answer }} - Score: {{ r.score }}</p>
+        <p>{{ r.date | date:'shortDate' }}</p>
+      </ion-label>
+    </ion-item>
+  </ion-list>
+
+  <ion-list *ngIf="wrongResults.length">
+    <ion-item lines="full">
+      <ion-label><strong>Wrong Answers</strong></ion-label>
+    </ion-item>
+    <ion-item *ngFor="let r of wrongResults">
       <ion-label>
         <h2>{{ r.question.text || r.question.question }}</h2>
         <p>Your Answer: {{ r.answer }} - Score: {{ r.score }}</p>


### PR DESCRIPTION
## Summary
- filter duplicate quiz entries and keep the best score
- group quiz history items by correctness
- display total score and separate lists for correct and wrong answers

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a2a1be148327892c0fc25545fbc4