### PR TITLE
Replace daily check-in button with SVG icon

### DIFF
--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -33,7 +33,9 @@
       <ng-container *ngIf="role === 'child'">
         <ion-row>
           <ion-col size="6">
-          <ion-button class="tile-button" routerLink="/tabs/check-in" expand="block">Daily Check-In</ion-button>
+          <ion-button class="tile-button" routerLink="/tabs/check-in" expand="block">
+            <img src="assets/tiles/dailycheckins.svg" alt="Daily Check-In" />
+          </ion-button>
           </ion-col>
           <ion-col size="6">
           <ion-button class="tile-button" routerLink="/tabs/mental-status" expand="block">Mood Appraisal</ion-button>

--- a/src/app/home/home.page.scss
+++ b/src/app/home/home.page.scss
@@ -18,3 +18,8 @@
   border-radius: 12px;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
 }
+
+.tile-button img {
+  width: 65%;
+  height: auto;
+}

--- a/src/assets/tiles/dailycheckins.svg
+++ b/src/assets/tiles/dailycheckins.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="10" y="20" width="80" height="70" rx="8" ry="8" fill="#dfe6e9" stroke="#636e72" stroke-width="2"/>
+  <rect x="10" y="10" width="80" height="20" fill="#74b9ff"/>
+  <path d="M30 55 L45 70 L70 40" fill="none" stroke="#2ecc71" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- add simple calendar SVG
- show calendar icon in daily check-in tile
- style tile image

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686225255eb88327bc89cfb8833a5b46