### PR TITLE
Replace homepage icons with text

### DIFF
--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -34,48 +34,56 @@
         <ion-row>
           <ion-col size="6">
           <ion-button class="tile-button" routerLink="/tabs/check-in" expand="block">
-            <img src="assets/tiles/dailycheckins.svg" alt="Daily Check-In" />
+            <!-- <img src="assets/tiles/dailycheckins.svg" alt="Daily Check-In" /> -->
+            <span>Daily Check-In</span>
           </ion-button>
           </ion-col>
           <ion-col size="6">
           <ion-button class="tile-button" routerLink="/tabs/mental-status" expand="block">
-            <img src="assets/tiles/moodappraisal.svg" alt="Mood Appraisal" />
+            <!-- <img src="assets/tiles/moodappraisal.svg" alt="Mood Appraisal" /> -->
+            <span>Mood Appraisal</span>
           </ion-button>
           </ion-col>
         </ion-row>
         <ion-row>
           <ion-col size="6">
           <ion-button class="tile-button" routerLink="/tabs/bible-quiz" expand="block">
-            <img src="assets/tiles/spiritualnourishment.svg" alt="Spiritual Nourishment" />
+            <!-- <img src="assets/tiles/spiritualnourishment.svg" alt="Spiritual Nourishment" /> -->
+            <span>Spiritual Nourishment</span>
           </ion-button>
           </ion-col>
           <ion-col size="6">
           <ion-button class="tile-button" routerLink="/tabs/essay-tracker" expand="block">
-            <img src="assets/tiles/essaytracker.svg" alt="Essay Tracker" />
+            <!-- <img src="assets/tiles/essaytracker.svg" alt="Essay Tracker" /> -->
+            <span>Essay Tracker</span>
           </ion-button>
           </ion-col>
         </ion-row>
         <ion-row>
           <ion-col size="6">
           <ion-button class="tile-button" routerLink="/tabs/academic-progress" expand="block">
-          <img src="assets/tiles/academicenhancement.svg" alt="Academic Enhancement" />
+          <!-- <img src="assets/tiles/academicenhancement.svg" alt="Academic Enhancement" /> -->
+          <span>Academic Enhancement</span>
           </ion-button>
           </ion-col>
           <ion-col size="6">
           <ion-button class="tile-button" routerLink="/tabs/project-tracker" expand="block">
-            <img src="assets/tiles/creativityincubator.svg" alt="Creativity Incubator" />
+            <!-- <img src="assets/tiles/creativityincubator.svg" alt="Creativity Incubator" /> -->
+            <span>Creativity Incubator</span>
           </ion-button>
           </ion-col>
         </ion-row>
         <ion-row>
           <ion-col size="6">
           <ion-button class="tile-button" routerLink="/tabs/leaderboard" expand="block">
-            <img src="assets/tiles/leaderboard.svg" alt="Leadership Board" />
+            <!-- <img src="assets/tiles/leaderboard.svg" alt="Leadership Board" /> -->
+            <span>Leadership Board</span>
           </ion-button>
           </ion-col>
           <ion-col size="6">
           <ion-button class="tile-button" routerLink="/tabs/quiz-history" expand="block">
-            <img src="assets/tiles/quizhistory.svg" alt="Quiz History" />
+            <!-- <img src="assets/tiles/quizhistory.svg" alt="Quiz History" /> -->
+            <span>Quiz History</span>
           </ion-button>
           </ion-col>
         </ion-row>

--- a/src/app/home/home.page.scss
+++ b/src/app/home/home.page.scss
@@ -23,3 +23,9 @@
   width: 100%;
   height: auto;
 }
+
+.tile-button span {
+  text-align: center;
+  font-size: 1rem;
+  padding: 4px;
+}


### PR DESCRIPTION
## Summary
- swap out homepage tile images with text labels
- style tile text in the home page SCSS

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863480b92d48327a09c3a4f9be0f3f2