### PR TITLE
Add mentor board feature

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -47,6 +47,14 @@ export const routes: Routes = [
         data: { title: 'Project Tracker' },
       },
       {
+        path: 'mentor-record',
+        loadComponent: () =>
+          import('./mentor-record/mentor-record.page').then(
+            (m) => m.MentorRecordPage
+          ),
+        data: { title: 'Mentor Board' },
+      },
+      {
         path: 'academic-progress',
         loadComponent: () =>
           import('./academic-progress/academic-progress.page').then(

--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -28,6 +28,11 @@
           <ion-button class="tile-button" routerLink="/tabs/leaderboard" expand="block">Leaderboard</ion-button>
         </ion-col>
       </ion-row>
+      <ion-row *ngIf="role === 'parent'">
+        <ion-col size="6">
+          <ion-button class="tile-button" routerLink="/tabs/mentor-record" expand="block">Mentor Board</ion-button>
+        </ion-col>
+      </ion-row>
 
       <!-- Child Buttons -->
       <ng-container *ngIf="role === 'child'">
@@ -84,6 +89,13 @@
           <ion-button class="tile-button" routerLink="/tabs/quiz-history" expand="block">
             <!-- <img src="assets/tiles/quizhistory.svg" alt="Quiz History" /> -->
             <span>Quiz History</span>
+          </ion-button>
+          </ion-col>
+        </ion-row>
+        <ion-row>
+          <ion-col size="6">
+          <ion-button class="tile-button" routerLink="/tabs/mentor-record" expand="block">
+            <span>Mentor Board</span>
           </ion-button>
           </ion-col>
         </ion-row>

--- a/src/app/mentor-record/mentor-record.page.html
+++ b/src/app/mentor-record/mentor-record.page.html
@@ -1,0 +1,21 @@
+<div class="ion-page">
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Mentor Board</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content>
+    <ion-list>
+      <ion-item *ngFor="let rec of records">
+        <ion-label>
+          <h2>{{ rec.title }}</h2>
+          <p>{{ rec.outline }}</p>
+          <p>Progress: {{ rec.progress }}%</p>
+          <p>Due: {{ rec.dueDate | date }}</p>
+          <p>Time remaining: {{ getTimeRemaining(rec.dueDate) }}</p>
+          <p *ngIf="rec.encouragement">{{ rec.encouragement }}</p>
+        </ion-label>
+      </ion-item>
+    </ion-list>
+  </ion-content>
+</div>

--- a/src/app/mentor-record/mentor-record.page.scss
+++ b/src/app/mentor-record/mentor-record.page.scss
@@ -1,0 +1,1 @@
+/* Add page styles if needed */

--- a/src/app/mentor-record/mentor-record.page.spec.ts
+++ b/src/app/mentor-record/mentor-record.page.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+import { MentorRecordPage } from './mentor-record.page';
+
+describe('MentorRecordPage', () => {
+  beforeEach(() => TestBed.configureTestingModule({ imports: [MentorRecordPage] }));
+
+  it('should create', () => {
+    const fixture = TestBed.createComponent(MentorRecordPage);
+    const app = fixture.componentInstance;
+    expect(app).toBeTruthy();
+  });
+});

--- a/src/app/mentor-record/mentor-record.page.ts
+++ b/src/app/mentor-record/mentor-record.page.ts
@@ -1,0 +1,62 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonContent,
+  IonList,
+  IonItem,
+  IonLabel
+} from '@ionic/angular/standalone';
+import { MentorRecordApiService } from '../services/mentor-record-api.service';
+import { FirebaseService } from '../services/firebase.service';
+import { MentorRecord } from '../models/mentor-record';
+
+@Component({
+  selector: 'app-mentor-record',
+  standalone: true,
+  imports: [
+    CommonModule,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
+    IonContent,
+    IonList,
+    IonItem,
+    IonLabel,
+  ],
+  templateUrl: './mentor-record.page.html',
+  styleUrls: ['./mentor-record.page.scss'],
+})
+export class MentorRecordPage implements OnInit {
+  records: MentorRecord[] = [];
+
+  constructor(
+    private api: MentorRecordApiService,
+    private fb: FirebaseService
+  ) {}
+
+  async ngOnInit() {
+    await this.loadRecords();
+  }
+
+  async ionViewWillEnter() {
+    await this.loadRecords();
+  }
+
+  getTimeRemaining(date: string): string {
+    const diff = new Date(date).getTime() - Date.now();
+    const days = Math.ceil(diff / (1000 * 60 * 60 * 24));
+    return days > 0 ? `${days} day(s)` : 'Past due';
+  }
+
+  private async loadRecords() {
+    const childId = this.fb.auth.currentUser?.uid;
+    if (!childId) {
+      this.records = [];
+      return;
+    }
+    this.api.getRecords(childId).subscribe((recs) => (this.records = recs));
+  }
+}

--- a/src/app/models/mentor-record.ts
+++ b/src/app/models/mentor-record.ts
@@ -1,0 +1,10 @@
+export interface MentorRecord {
+  title: string;
+  outline: string;
+  progress: number;
+  dueDate: string;
+  encouragement?: string;
+  childId?: string | null;
+  mentorId?: string | null;
+  updatedAt: string;
+}

--- a/src/app/services/firebase.service.ts
+++ b/src/app/services/firebase.service.ts
@@ -35,6 +35,7 @@ import { ProjectEntry } from '../models/project-entry';
 import { LeaderboardEntry, UserStats } from '../models/user-stats';
 import { ParentChildLink } from '../models/parent-child-link';
 import { MentorChildLink } from '../models/mentor-child-link';
+import { MentorRecord } from '../models/mentor-record';
 @Injectable({ providedIn: 'root' })
 export class FirebaseService {
   private app = initializeApp(environment.firebase);
@@ -246,5 +247,21 @@ export class FirebaseService {
     );
     const snap = await getDocs(q);
     return snap.docs.map((d) => (d.data() as MentorChildLink).childId);
+  }
+
+  saveMentorRecord(data: MentorRecord) {
+    return addDoc(collection(this.db, 'mentorRecords'), data);
+  }
+
+  async getMentorRecords(childId: string): Promise<MentorRecord[]> {
+    const q = query(
+      collection(this.db, 'mentorRecords'),
+      where('childId', '==', childId),
+      orderBy('dueDate', 'asc')
+    );
+    const snap = await getDocs(q);
+    return snap.docs.map(
+      (d) => ({ id: d.id, ...(d.data() as Omit<MentorRecord, 'id'>) })
+    );
   }
 }

--- a/src/app/services/mentor-record-api.service.ts
+++ b/src/app/services/mentor-record-api.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, from } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
+import { FirebaseService } from './firebase.service';
+import { MentorRecord } from '../models/mentor-record';
+
+@Injectable({ providedIn: 'root' })
+export class MentorRecordApiService {
+  private apiEnabled = !!environment.apiUrl;
+  private readonly baseUrl = `${environment.apiUrl}/api/mentorship`;
+
+  constructor(private http: HttpClient, private fb: FirebaseService) {}
+
+  getRecords(childId: string): Observable<MentorRecord[]> {
+    if (!this.apiEnabled) {
+      return from(this.fb.getMentorRecords(childId));
+    }
+    return this.http
+      .get<MentorRecord[]>(`${this.baseUrl}/${childId}/records`)
+      .pipe(catchError(() => from(this.fb.getMentorRecords(childId))));
+  }
+}

--- a/src/app/tabs/tabs.page.html
+++ b/src/app/tabs/tabs.page.html
@@ -29,6 +29,10 @@
         <ion-icon name="trophy-outline"></ion-icon>
         <ion-label>Scores</ion-label>
       </ion-tab-button>
+      <ion-tab-button tab="mentor-record" href="/tabs/mentor-record">
+        <ion-icon name="chatbubble-ellipses-outline"></ion-icon>
+        <ion-label>Mentor</ion-label>
+      </ion-tab-button>
     </ng-container>
     <ng-template #childTabs>
       <ion-tab-button tab="check-in" href="/tabs/check-in">
@@ -50,6 +54,10 @@
       <ion-tab-button tab="quiz-history" href="/tabs/quiz-history">
         <ion-icon name="time-outline"></ion-icon>
         <ion-label>History</ion-label>
+      </ion-tab-button>
+      <ion-tab-button tab="mentor-record" href="/tabs/mentor-record">
+        <ion-icon name="chatbubble-ellipses-outline"></ion-icon>
+        <ion-label>Mentor</ion-label>
       </ion-tab-button>
     </ng-template>
       <ion-button fill="clear" (click)="logout()">


### PR DESCRIPTION
## Summary
- create mentor record page and models
- fetch mentor records from API or firestore
- register mentor board route and add nav buttons
- expose mentor records in Firebase service
- link page from home tiles

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884fd8554a08327ae27f8e37e2d41ac