### PR TITLE
Add reward center page and Firestore helpers

### DIFF
--- a/docs/admin-flow.md
+++ b/docs/admin-flow.md
@@ -1,0 +1,20 @@
+# Reward Center Admin Flow
+
+This document explains how administrators can adjust point totals and how parents request changes.
+
+## Admin Accounts
+
+Administrators are Firebase users with the custom auth claim `admin: true`. The Firestore rules allow these users to update any document in `/userStats`.
+
+Set the claim using the Firebase Admin SDK:
+
+```ts
+import { getAuth } from 'firebase-admin/auth';
+await getAuth().setCustomUserClaims(uid, { admin: true });
+```
+
+## Parent Requests
+
+Parents should email the admin team with their child's UID and the number of points to award. After verifying the request, an admin updates `/userStats/{childId}` in the Firebase console or through an internal admin screen.
+
+Updating the document will immediately reflect in the child's Reward Center page.

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -10,6 +10,10 @@ service cloud.firestore {
       return request.auth != null && request.auth.uid == doc.data.childId;
     }
 
+    function isAdmin() {
+      return request.auth != null && request.auth.token.admin == true;
+    }
+
     match /parentChildLinks/{linkId} {
       allow read: if request.auth != null && (isParent(resource) || isChild(resource));
       allow write: if request.auth != null && request.auth.uid == request.resource.data.parentId;
@@ -59,8 +63,8 @@ service cloud.firestore {
     match /userStats/{userId} {
       // Any authenticated user can read leaderboard data
       allow read: if request.auth != null;
-      // Only the child account may update their stats
-      allow create, update: if request.auth != null && request.auth.uid == userId;
+      // Child account or admins may update stats
+      allow create, update: if request.auth != null && (request.auth.uid == userId || isAdmin());
       allow delete: if false;
     }
   }

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -77,6 +77,14 @@ export const routes: Routes = [
         data: { title: 'Leaderboard' },
       },
       {
+        path: 'reward-center',
+        loadComponent: () =>
+          import('./reward-center/reward-center.page').then(
+            (m) => m.RewardCenterPage
+          ),
+        data: { title: 'Reward Center' },
+      },
+      {
         path: 'mental-status',
         loadComponent: () =>
           import('./mental-status/mental-status.page').then(

--- a/src/app/models/notification.ts
+++ b/src/app/models/notification.ts
@@ -1,0 +1,7 @@
+export interface AppNotification {
+  id?: string;
+  parentId?: string;
+  childId?: string;
+  message: string;
+  date: string;
+}

--- a/src/app/reward-center/reward-center.page.html
+++ b/src/app/reward-center/reward-center.page.html
@@ -1,0 +1,18 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Reward Center</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+  <div class="stats" *ngIf="stats">
+    <h2>{{ stats.points }} pts</h2>
+    <p>Streak: {{ stats.streak || 0 }}</p>
+  </div>
+
+  <ion-list>
+    <ion-item *ngFor="let note of notifications">
+      <ion-label>{{ note.message }} - {{ note.date | date:'short' }}</ion-label>
+    </ion-item>
+  </ion-list>
+</ion-content>

--- a/src/app/reward-center/reward-center.page.scss
+++ b/src/app/reward-center/reward-center.page.scss
@@ -1,0 +1,4 @@
+.stats {
+  text-align: center;
+  margin: 1rem 0;
+}

--- a/src/app/reward-center/reward-center.page.ts
+++ b/src/app/reward-center/reward-center.page.ts
@@ -1,0 +1,59 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonContent,
+  IonList,
+  IonItem,
+  IonLabel,
+} from '@ionic/angular/standalone';
+import { FirebaseService } from '../services/firebase.service';
+import { UserStats } from '../models/user-stats';
+import { AppNotification } from '../models/notification';
+
+@Component({
+  selector: 'app-reward-center',
+  standalone: true,
+  imports: [
+    CommonModule,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
+    IonContent,
+    IonList,
+    IonItem,
+    IonLabel,
+  ],
+  templateUrl: './reward-center.page.html',
+  styleUrls: ['./reward-center.page.scss'],
+})
+export class RewardCenterPage implements OnInit {
+  stats: UserStats | null = null;
+  notifications: AppNotification[] = [];
+
+  constructor(private fb: FirebaseService) {}
+
+  async ngOnInit() {
+    await this.loadData();
+  }
+
+  async ionViewWillEnter() {
+    await this.loadData();
+  }
+
+  private async loadData() {
+    const user = this.fb.auth.currentUser;
+    if (!user) {
+      this.stats = null;
+      this.notifications = [];
+      return;
+    }
+    this.stats = await this.fb.getUserStats(user.uid);
+    const parentId = await this.fb.getParentIdForChild(user.uid);
+    if (parentId) {
+      this.notifications = await this.fb.getNotifications(parentId);
+    }
+  }
+}

--- a/src/app/tabs/tabs.page.html
+++ b/src/app/tabs/tabs.page.html
@@ -55,6 +55,10 @@
         <ion-icon name="time-outline"></ion-icon>
         <ion-label>History</ion-label>
       </ion-tab-button>
+      <ion-tab-button tab="reward-center" href="/tabs/reward-center">
+        <ion-icon name="gift-outline"></ion-icon>
+        <ion-label>Rewards</ion-label>
+      </ion-tab-button>
       <ion-tab-button tab="mentor-record" href="/tabs/mentor-record">
         <ion-icon name="chatbubble-ellipses-outline"></ion-icon>
         <ion-label>Mentor</ion-label>


### PR DESCRIPTION
## Summary
- implement getUserStats and getNotifications in Firebase service
- create Reward Center page to show points and notifications
- hook up new page in router and tabs
- allow admin users to update `/userStats` in Firestore rules
- document admin workflow for awarding points

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885191e1b5c83278573b216d1fd8db3