### PR TITLE
Fix mentor board access

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -67,5 +67,15 @@ service cloud.firestore {
       allow create, update: if request.auth != null && (request.auth.uid == userId || isAdmin());
       allow delete: if false;
     }
+
+    match /mentorRecords/{docId} {
+      // Child linked to the record or the mentor who created it may read
+      allow read: if request.auth != null &&
+        (request.auth.uid == resource.data.childId || request.auth.uid == resource.data.mentorId);
+      // Only the mentor who created the record (or admins) may add new ones
+      allow create: if request.auth != null &&
+        (request.auth.uid == request.resource.data.mentorId || isAdmin());
+      allow update, delete: if false;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- allow reading mentor board records for child and mentor users
- permit mentors to create new mentor records

## Testing
- `npm install` *(fails: Could not reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_688531a156808327aa319222b6e0a0f9