### PR TITLE
Fix index signature access for date field

### DIFF
--- a/src/app/services/firebase.service.ts
+++ b/src/app/services/firebase.service.ts
@@ -206,7 +206,7 @@ export class FirebaseService {
     const docs = [...parentSnap.docs, ...childSnap.docs];
     return docs
       .sort((a, b) =>
-        (b.data().date || '').localeCompare(a.data().date || '')
+        (b.data()['date'] || '').localeCompare(a.data()['date'] || '')
       )
       .slice(0, limitCount)
       .map((d) => ({ id: d.id, ...(d.data() as Omit<AppNotification, 'id'>) }));


### PR DESCRIPTION
## Summary
- fix TS4111 by switching to bracket syntax for `date` access in firebase service

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm ci` *(fails: cannot reach registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68857f5d093c83278d216f30f6ed1d97