### PR TITLE
Fix mentor records by using Firebase fallback

### DIFF
--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -14,8 +14,10 @@ export const environment = {
     appId: "1:54742577057:web:cfca5e902ab173a77025e0",
     measurementId: "G-91V8B05X5E"
   },
-  // Leave apiUrl empty when no backend service is available.
-  apiUrl: 'https://gfharvestbackend-1.onrender.com'
+  // Leave apiUrl empty when no backend service is available. Using an empty
+  // string ensures the application falls back to Firebase when the backend
+  // API is not running during local development.
+  apiUrl: ''
 };
 
 


### PR DESCRIPTION
## Summary
- use Firebase by default in development when the backend is unavailable

The fix ensures navigating to the Mentor Board doesn't try to hit a backend endpoint that may not be running.

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm install` *(fails: network disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6885a30272cc8327aa369bbb0c215ce4