### PR TITLE
Fix tab icon imports and improve tabs

### DIFF
--- a/src/app/tabs/tabs.page.html
+++ b/src/app/tabs/tabs.page.html
@@ -2,7 +2,7 @@
 <ion-header *ngIf="loggedIn">
     <ion-toolbar>
       <ion-buttons slot="start">
-        <ion-button routerLink="home">
+        <ion-button routerLink="/tabs/home">
           <ion-icon name="home-outline"></ion-icon>
         </ion-button>
       </ion-buttons>

--- a/src/app/tabs/tabs.page.scss
+++ b/src/app/tabs/tabs.page.scss
@@ -1,0 +1,13 @@
+ion-tab-bar {
+  display: flex;
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+ion-tab-bar::-webkit-scrollbar {
+  display: none;
+}
+
+ion-tab-button {
+  flex: 0 0 auto;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,8 @@ import {
   personAddOutline,
   trophyOutline,
   timeOutline,
+  giftOutline,
+  chatbubbleEllipsesOutline,
 } from 'ionicons/icons';
 import { AuthInterceptor } from './app/services/auth.interceptor';
 
@@ -38,6 +40,8 @@ addIcons({
   personAddOutline,
   trophyOutline,
   timeOutline,
+  giftOutline,
+  chatbubbleEllipsesOutline,
 });
 
 bootstrapApplication(AppComponent, {


### PR DESCRIPTION
## Summary
- import missing gift and mentor icons
- fix Home button route
- allow tab bar to scroll when too many tabs

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886199df3608327bd1ee012061a85ff