### PR TITLE
Add side menu with 3-tab bottom bar

### DIFF
--- a/src/app/tabs/tabs.page.html
+++ b/src/app/tabs/tabs.page.html
@@ -1,72 +1,96 @@
 
-<ion-header *ngIf="loggedIn">
+<ion-menu contentId="main-tabs" side="start">
+  <ion-header>
     <ion-toolbar>
-      <ion-buttons slot="start">
-        <ion-button routerLink="/tabs/home">
-          <ion-icon name="home-outline"></ion-icon>
-        </ion-button>
-      </ion-buttons>
-      <ion-title>{{ pageTitle }}</ion-title>
-      <ion-buttons slot="end">
-        <ion-button (click)="logout()">
-          <ion-icon name="log-out-outline"></ion-icon>
-        </ion-button>
-      </ion-buttons>
+      <ion-title>Menu</ion-title>
     </ion-toolbar>
   </ion-header>
-<ion-tabs>
-  <ion-tab-bar slot="bottom">
-    <ng-container *ngIf="role === 'parent'; else childTabs">
-      <ion-tab-button tab="home" href="/tabs/home">
-        <ion-icon name="home-outline"></ion-icon>
-        <ion-label>Home</ion-label>
-      </ion-tab-button>
-      <ion-tab-button tab="child-account" href="/tabs/child-account">
-        <ion-icon name="person-add-outline"></ion-icon>
-        <ion-label>Child</ion-label>
-      </ion-tab-button>
-      <ion-tab-button tab="leaderboard" href="/tabs/leaderboard">
-        <ion-icon name="trophy-outline"></ion-icon>
-        <ion-label>Scores</ion-label>
-      </ion-tab-button>
-      <ion-tab-button tab="mentor-record" href="/tabs/mentor-record">
-        <ion-icon name="chatbubble-ellipses-outline"></ion-icon>
-        <ion-label>Mentor</ion-label>
-      </ion-tab-button>
-    </ng-container>
-    <ng-template #childTabs>
-      <ion-tab-button tab="check-in" href="/tabs/check-in">
-        <ion-icon name="calendar-outline"></ion-icon>
-        <ion-label>Check-In</ion-label>
-      </ion-tab-button>
-      <ion-tab-button tab="bible-quiz" href="/tabs/bible-quiz">
-        <ion-icon name="help-outline"></ion-icon>
-        <ion-label>Quiz</ion-label>
-      </ion-tab-button>
-      <ion-tab-button tab="essay-tracker" href="/tabs/essay-tracker">
-        <ion-icon name="create-outline"></ion-icon>
-        <ion-label>Essay</ion-label>
-      </ion-tab-button>
-      <ion-tab-button tab="project-tracker" href="/tabs/project-tracker">
-        <ion-icon name="list-outline"></ion-icon>
-        <ion-label>Projects</ion-label>
-      </ion-tab-button>
-      <ion-tab-button tab="quiz-history" href="/tabs/quiz-history">
-        <ion-icon name="time-outline"></ion-icon>
-        <ion-label>History</ion-label>
-      </ion-tab-button>
-      <ion-tab-button tab="reward-center" href="/tabs/reward-center">
-        <ion-icon name="gift-outline"></ion-icon>
-        <ion-label>Rewards</ion-label>
-      </ion-tab-button>
-      <ion-tab-button tab="mentor-record" href="/tabs/mentor-record">
-        <ion-icon name="chatbubble-ellipses-outline"></ion-icon>
-        <ion-label>Mentor</ion-label>
-      </ion-tab-button>
-    </ng-template>
-      <ion-button fill="clear" (click)="logout()">
+  <ion-content>
+    <ion-list>
+      <ion-menu-toggle auto-hide="true">
+        <ion-item routerLink="/tabs/home">
+          <ion-icon slot="start" name="home-outline"></ion-icon>
+          <ion-label>Home</ion-label>
+        </ion-item>
+        <ion-item routerLink="/tabs/check-in">
+          <ion-icon slot="start" name="calendar-outline"></ion-icon>
+          <ion-label>Daily Check-In</ion-label>
+        </ion-item>
+        <ion-item routerLink="/tabs/bible-quiz">
+          <ion-icon slot="start" name="help-outline"></ion-icon>
+          <ion-label>Bible Quiz</ion-label>
+        </ion-item>
+        <ion-item routerLink="/tabs/quiz-history">
+          <ion-icon slot="start" name="time-outline"></ion-icon>
+          <ion-label>Quiz History</ion-label>
+        </ion-item>
+        <ion-item routerLink="/tabs/essay-tracker">
+          <ion-icon slot="start" name="create-outline"></ion-icon>
+          <ion-label>Essay Tracker</ion-label>
+        </ion-item>
+        <ion-item routerLink="/tabs/project-tracker">
+          <ion-icon slot="start" name="list-outline"></ion-icon>
+          <ion-label>Project Tracker</ion-label>
+        </ion-item>
+        <ion-item routerLink="/tabs/academic-progress">
+          <ion-icon slot="start" name="school-outline"></ion-icon>
+          <ion-label>Academic Progress</ion-label>
+        </ion-item>
+        <ion-item routerLink="/tabs/mental-status">
+          <ion-icon slot="start" name="happy-outline"></ion-icon>
+          <ion-label>Mental Status</ion-label>
+        </ion-item>
+        <ion-item routerLink="/tabs/leaderboard">
+          <ion-icon slot="start" name="trophy-outline"></ion-icon>
+          <ion-label>Leaderboard</ion-label>
+        </ion-item>
+        <ion-item routerLink="/tabs/child-account">
+          <ion-icon slot="start" name="person-add-outline"></ion-icon>
+          <ion-label>Create Child</ion-label>
+        </ion-item>
+        <ion-item routerLink="/tabs/reward-center">
+          <ion-icon slot="start" name="gift-outline"></ion-icon>
+          <ion-label>Reward Center</ion-label>
+        </ion-item>
+        <ion-item routerLink="/tabs/mentor-record">
+          <ion-icon slot="start" name="chatbubble-ellipses-outline"></ion-icon>
+          <ion-label>Mentor Board</ion-label>
+        </ion-item>
+      </ion-menu-toggle>
+    </ion-list>
+  </ion-content>
+</ion-menu>
+
+<ion-header *ngIf="loggedIn">
+  <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-menu-button></ion-menu-button>
+    </ion-buttons>
+    <ion-title>{{ pageTitle }}</ion-title>
+    <ion-buttons slot="end">
+      <ion-button (click)="logout()">
         <ion-icon name="log-out-outline"></ion-icon>
       </ion-button>
-  </ion-tab-bar>
+    </ion-buttons>
+  </ion-toolbar>
+</ion-header>
 
+<ion-tabs id="main-tabs">
+  <ion-tab-bar slot="bottom">
+    <ion-tab-button tab="home" href="/tabs/home">
+      <ion-icon name="home-outline"></ion-icon>
+      <ion-label>Home</ion-label>
+    </ion-tab-button>
+    <ion-tab-button tab="mentor-record" href="/tabs/mentor-record">
+      <ion-icon name="chatbubble-ellipses-outline"></ion-icon>
+      <ion-label>Mentor</ion-label>
+    </ion-tab-button>
+    <ion-tab-button tab="reward-center" href="/tabs/reward-center">
+      <ion-icon name="gift-outline"></ion-icon>
+      <ion-label>Rewards</ion-label>
+    </ion-tab-button>
+    <ion-button fill="clear" (click)="logout()">
+      <ion-icon name="log-out-outline"></ion-icon>
+    </ion-button>
+  </ion-tab-bar>
 </ion-tabs>

--- a/src/app/tabs/tabs.page.ts
+++ b/src/app/tabs/tabs.page.ts
@@ -11,6 +11,12 @@ import {
   IonTitle,
   IonToolbar,
   IonHeader,
+  IonMenu,
+  IonMenuToggle,
+  IonMenuButton,
+  IonList,
+  IonItem,
+  IonContent,
 } from '@ionic/angular/standalone';
 import { Router, ActivatedRoute, NavigationEnd } from '@angular/router';
 import { RoleService } from '../services/role.service';
@@ -32,6 +38,12 @@ import { filter } from 'rxjs/operators';
     IonTitle,
     IonToolbar,
     IonHeader,
+    IonMenu,
+    IonMenuToggle,
+    IonMenuButton,
+    IonList,
+    IonItem,
+    IonContent,
   ],
   templateUrl: './tabs.page.html',
   styleUrls: ['./tabs.page.scss'],


### PR DESCRIPTION
## Summary
- simplify tab bar to three tabs: Home, Mentor and Rewards
- add a new side menu listing all pages
- hook up hamburger button to open the new menu

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_688620bca950832793026382253f78f9