### PR TITLE
Fix unknown element error for ion-title

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -9,6 +9,7 @@ import {
   IonList,
   IonItem,
   IonMenuToggle,
+  IonTitle,
   IonIcon,
   IonLabel,
 } from '@ionic/angular/standalone';
@@ -29,6 +30,7 @@ import { RoleService } from './services/role.service';
     IonList,
     IonItem,
     IonMenuToggle,
+    IonTitle,
     IonIcon,
     IonLabel,
   ],


### PR DESCRIPTION
## Summary
- add missing `IonTitle` import for the standalone `AppComponent`

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68862fed36b08327b23e19b60a0c9b58