### PR TITLE
Fix Ion menu button icon

### DIFF
--- a/src/app/tabs/tabs.page.html
+++ b/src/app/tabs/tabs.page.html
@@ -1,7 +1,7 @@
 <ion-header *ngIf="loggedIn">
   <ion-toolbar>
     <ion-buttons slot="start">
-      <ion-menu-button>button</ion-menu-button>
+      <ion-menu-button></ion-menu-button>
     </ion-buttons>
     <!-- <ion-title>{{ pageTitle }}</ion-title> -->
     <ion-buttons slot="end">


### PR DESCRIPTION
## Summary
- remove stray text inside `<ion-menu-button>` so the icon renders correctly

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68867a45a2888327a4de000006fcd107