### PR TITLE
Fix Ionicons missing icons

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,8 @@ import {
   helpOutline,
   createOutline,
   listOutline,
+  schoolOutline,
+  happyOutline,
   homeOutline,
   logOutOutline,
   personAddOutline,
@@ -42,6 +44,8 @@ addIcons({
   timeOutline,
   giftOutline,
   chatbubbleEllipsesOutline,
+  schoolOutline,
+  happyOutline,
 });
 
 bootstrapApplication(AppComponent, {


### PR DESCRIPTION
## Summary
- register missing Ionicons so menu icons display in production

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68867d7b500883279ab1be7af247b71c