### PR TITLE
Fix menu icon not showing in production

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,7 @@ import {
   timeOutline,
   giftOutline,
   chatbubbleEllipsesOutline,
+  menuOutline,
 } from 'ionicons/icons';
 import { AuthInterceptor } from './app/services/auth.interceptor';
 
@@ -46,6 +47,7 @@ addIcons({
   chatbubbleEllipsesOutline,
   schoolOutline,
   happyOutline,
+  menuOutline,
 });
 
 bootstrapApplication(AppComponent, {


### PR DESCRIPTION
## Summary
- register the `menuOutline` ionicon so the `<ion-menu-button>` icon works in production

## Testing
- `npm ci` *(fails: unable to reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_68868205b79483279f3e89881d36b5c0