### PR TITLE
Add reward center tile

### DIFF
--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -98,6 +98,11 @@
             <span>Mentor Board</span>
           </ion-button>
           </ion-col>
+          <ion-col size="6">
+          <ion-button class="tile-button" routerLink="/tabs/reward-center" expand="block">
+            <span>Reward Center</span>
+          </ion-button>
+          </ion-col>
         </ion-row>
       </ng-container>
     </ion-grid>


### PR DESCRIPTION
## Summary
- add Reward Center shortcut in home tiles

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_688aa68a52248327ab5b97750b141cf4