### PR TITLE
Fix menu icon missing after refresh

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ import {
   giftOutline,
   chatbubbleEllipsesOutline,
   menuOutline,
+  menu,
 } from 'ionicons/icons';
 import { AuthInterceptor } from './app/services/auth.interceptor';
 
@@ -48,6 +49,7 @@ addIcons({
   'gift-outline': giftOutline,
   'chatbubble-ellipses-outline': chatbubbleEllipsesOutline,
   'menu-outline': menuOutline,
+  'menu': menu,
 });
 
 bootstrapApplication(AppComponent, {


### PR DESCRIPTION
## Summary
- register `menu` icon to ensure IonMenuButton icon is available

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_688aea7a330c83278be50d29d5ae20b8