### PR TITLE
Add group bar chart example

### DIFF
--- a/src/app/reward-center/group-bar-chart/group-bar-chart.component.html
+++ b/src/app/reward-center/group-bar-chart/group-bar-chart.component.html
@@ -1,0 +1,11 @@
+<div class="chart">
+  <div class="category" *ngFor="let g of groups">
+    <h4>{{ g.name }}</h4>
+    <div class="bar" [style.width.%]="(g.faith / maxValue) * 100" title="Faith: {{g.faith}}"></div>
+    <div class="bar" [style.width.%]="(g.discipline / maxValue) * 100" title="Discipline: {{g.discipline}}"></div>
+    <div class="bar" [style.width.%]="(g.knowledge / maxValue) * 100" title="Knowledge: {{g.knowledge}}"></div>
+    <div class="bar" [style.width.%]="(g.prayer / maxValue) * 100" title="Prayer: {{g.prayer}}"></div>
+    <div class="bar" [style.width.%]="(g.obedience / maxValue) * 100" title="Obedience: {{g.obedience}}"></div>
+    <div class="bar composite" [style.width.%]="(g.composite / maxValue) * 100" title="Composite: {{g.composite}}"></div>
+  </div>
+</div>

--- a/src/app/reward-center/group-bar-chart/group-bar-chart.component.scss
+++ b/src/app/reward-center/group-bar-chart/group-bar-chart.component.scss
@@ -1,0 +1,21 @@
+.chart {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.category {
+  display: flex;
+  flex-direction: column;
+}
+
+.bar {
+  height: 8px;
+  background: var(--ion-color-primary);
+  margin: 2px 0;
+}
+
+.bar.composite {
+  background: var(--ion-color-secondary);
+  height: 10px;
+}

--- a/src/app/reward-center/group-bar-chart/group-bar-chart.component.ts
+++ b/src/app/reward-center/group-bar-chart/group-bar-chart.component.ts
@@ -1,0 +1,33 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+interface GroupData {
+  name: string;
+  faith: number;
+  discipline: number;
+  knowledge: number;
+  prayer: number;
+  obedience: number;
+  composite: number;
+}
+
+@Component({
+  selector: 'app-group-bar-chart',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './group-bar-chart.component.html',
+  styleUrls: ['./group-bar-chart.component.scss']
+})
+export class GroupBarChartComponent {
+  groups: GroupData[] = [
+    { name: 'Group A', faith: 80, discipline: 75, knowledge: 85, prayer: 90, obedience: 70, composite: 80 },
+    { name: 'Group B', faith: 60, discipline: 65, knowledge: 70, prayer: 75, obedience: 80, composite: 70 },
+    { name: 'Group C', faith: 90, discipline: 85, knowledge: 80, prayer: 85, obedience: 95, composite: 87 },
+    { name: 'Group D', faith: 70, discipline: 60, knowledge: 75, prayer: 65, obedience: 80, composite: 70 }
+  ];
+
+  get maxValue(): number {
+    return Math.max(...this.groups.flatMap(g => [g.faith, g.discipline, g.knowledge, g.prayer, g.obedience, g.composite]), 100);
+  }
+}
+

--- a/src/app/reward-center/reward-center.page.html
+++ b/src/app/reward-center/reward-center.page.html
@@ -25,5 +25,6 @@
         <ion-progress-bar [value]="g.points / maxGroupPoints"></ion-progress-bar>
       </ion-item>
     </ion-list>
+    <app-group-bar-chart></app-group-bar-chart>
   </div>
 </ion-content>

--- a/src/app/reward-center/reward-center.page.ts
+++ b/src/app/reward-center/reward-center.page.ts
@@ -14,6 +14,7 @@ import { FirebaseService } from '../services/firebase.service';
 import { UserStats } from '../models/user-stats';
 import { AppNotification } from '../models/notification';
 import { PointsJarComponent } from './points-jar/points-jar.component';
+import { GroupBarChartComponent } from './group-bar-chart/group-bar-chart.component';
 import { GroupApiService } from '../services/group-api.service';
 import { GroupPoints } from '../models/group-stats';
 import { firstValueFrom } from 'rxjs';
@@ -32,6 +33,7 @@ import { firstValueFrom } from 'rxjs';
     IonLabel,
     IonProgressBar,
     PointsJarComponent,
+    GroupBarChartComponent,
   ],
   templateUrl: './reward-center.page.html',
   styleUrls: ['./reward-center.page.scss'],


### PR DESCRIPTION
## Summary
- add a simple group bar chart component
- show group bar chart in the reward center

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b8ef86ec08327bf198f41d86fbc95