### PR TITLE
Fix implicit any in group-bar-chart

### DIFF
--- a/src/app/reward-center/group-bar-chart/group-bar-chart.component.ts
+++ b/src/app/reward-center/group-bar-chart/group-bar-chart.component.ts
@@ -27,7 +27,17 @@ export class GroupBarChartComponent {
   ];
 
   get maxValue(): number {
-    return Math.max(...this.groups.flatMap(g => [g.faith, g.discipline, g.knowledge, g.prayer, g.obedience, g.composite]), 100);
+    return Math.max(
+      ...this.groups.flatMap((g: GroupData) => [
+        g.faith,
+        g.discipline,
+        g.knowledge,
+        g.prayer,
+        g.obedience,
+        g.composite,
+      ]),
+      100,
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- explicitly type the flatMap callback in `group-bar-chart.component.ts`

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b9135a7d08327b08bfffee8b5be45