### PR TITLE
Fix points jar display and streak defaults

### DIFF
--- a/src/app/reward-center/reward-center.page.html
+++ b/src/app/reward-center/reward-center.page.html
@@ -16,8 +16,6 @@
       <ion-label>{{ note.message }} - {{ note.date | date:'short' }}</ion-label>
     </ion-item>
   </ion-list>
-  <br />
-<app-points-jar></app-points-jar>
   <div *ngIf="groups.length">
     <h3 class="group-header">Group Points</h3>
     <ion-list>

--- a/src/app/services/firebase.service.ts
+++ b/src/app/services/firebase.service.ts
@@ -220,7 +220,15 @@ export class FirebaseService {
   async getUserStats(childId: string): Promise<UserStats | null> {
     const ref = doc(this.db, 'userStats', childId);
     const snap = await getDoc(ref);
-    return snap.exists() ? (snap.data() as UserStats) : null;
+    if (!snap.exists()) {
+      return null;
+    }
+    const data = snap.data() as Partial<UserStats>;
+    return {
+      streak: data.streak || 0,
+      lastCheckInDate: data.lastCheckInDate || '',
+      points: data.points || 0,
+    };
   }
 
   async updateStreak(childId: string) {


### PR DESCRIPTION
## Summary
- ensure user stats defaults so streak always displays
- remove unused jar to show correct points

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b9f315d248327a5bee824d847234c