### PR TITLE
Add points API service for reward center

### DIFF
--- a/src/app/reward-center/reward-center.page.ts
+++ b/src/app/reward-center/reward-center.page.ts
@@ -16,6 +16,7 @@ import { AppNotification } from '../models/notification';
 import { PointsJarComponent } from './points-jar/points-jar.component';
 import { GroupBarChartComponent } from './group-bar-chart/group-bar-chart.component';
 import { GroupApiService } from '../services/group-api.service';
+import { PointsApiService } from '../services/points-api.service';
 import { GroupPoints } from '../models/group-stats';
 import { firstValueFrom } from 'rxjs';
 
@@ -45,7 +46,11 @@ export class RewardCenterPage implements OnInit {
   animateJar = false;
   maxGroupPoints = 1;
 
-  constructor(private fb: FirebaseService, private groupApi: GroupApiService) {}
+  constructor(
+    private fb: FirebaseService,
+    private groupApi: GroupApiService,
+    private pointsApi: PointsApiService
+  ) {}
 
   async ngOnInit() {
     await this.loadData();
@@ -63,7 +68,9 @@ export class RewardCenterPage implements OnInit {
       this.groups = [];
       return;
     }
-    this.stats = await this.fb.getUserStats(user.uid);
+    this.stats = await firstValueFrom(
+      this.pointsApi.getChildPoints(user.uid)
+    );
     const last = Number(localStorage.getItem('lastPoints')) || 0;
     if (this.stats && this.stats.points > last) {
       this.animateJar = true;

--- a/src/app/services/points-api.service.ts
+++ b/src/app/services/points-api.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, from } from 'rxjs';
+import { catchError, timeout } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
+import { FirebaseService } from './firebase.service';
+import { UserStats } from '../models/user-stats';
+
+@Injectable({ providedIn: 'root' })
+export class PointsApiService {
+  private apiEnabled = !!environment.apiUrl;
+  private readonly baseUrl = `${environment.apiUrl}/api/points`;
+
+  constructor(private http: HttpClient, private fb: FirebaseService) {}
+
+  grantPoints(childId: string, points: number): Observable<unknown> {
+    if (!this.apiEnabled) {
+      return from(this.fb.addPoints(childId, points));
+    }
+    return this.http
+      .post(`${this.baseUrl}/grant`, { childId, points })
+      .pipe(timeout(5000), catchError(() => from(this.fb.addPoints(childId, points))));
+  }
+
+  getChildPoints(childId: string): Observable<UserStats | null> {
+    if (!this.apiEnabled) {
+      return from(this.fb.getUserStats(childId));
+    }
+    return this.http
+      .get<UserStats>(`${this.baseUrl}/${childId}`)
+      .pipe(timeout(5000), catchError(() => from(this.fb.getUserStats(childId))));
+  }
+}


### PR DESCRIPTION
## Summary
- implement PointsApiService to call new `/api/points` backend routes
- use PointsApiService in reward center page to fetch child stats

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bd3c3316c83278e0737ff7f34fcea