### PR TITLE
Fix needs help checkbox

### DIFF
--- a/src/app/check-in/check-in.page.html
+++ b/src/app/check-in/check-in.page.html
@@ -65,7 +65,11 @@
     </ion-item>
     <ion-item>
       <ion-label>Need Help?</ion-label>
-      <ion-checkbox slot="start" [(ngModel)]="form.needsHelp"></ion-checkbox>
+      <ion-checkbox
+        slot="start"
+        [checked]="form.needsHelp"
+        (ionChange)="form.needsHelp = $event.detail.checked"
+      ></ion-checkbox>
     </ion-item>
     <ion-item *ngIf="form.needsHelp">
       <ion-label position="stacked">How can we help?</ion-label>


### PR DESCRIPTION
## Summary
- fix event binding for needs help checkbox on Check In page

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c0a6ee89c8327baf2f58dba70ac53