### PR TITLE
Fix Ionicons not loading after refresh

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import {
   provideIonicAngular,
 } from '@ionic/angular/standalone';
 import { addIcons } from 'ionicons';
+import { defineCustomElements as defineIonIcons } from 'ionicons/loader';
 import {
   calendarOutline,
   helpOutline,
@@ -33,6 +34,8 @@ import { AuthInterceptor } from './app/services/auth.interceptor';
 
 import { routes } from './app/app.routes';
 import { AppComponent } from './app/app.component';
+
+defineIonIcons(window);
 
 addIcons({
   'calendar-outline': calendarOutline,


### PR DESCRIPTION
## Summary
- ensure Ionicons custom elements get registered

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_688d04a41ef08327ad03bda6f1f80dcf