### PR TITLE
Fix ionicons loader path

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ import {
   provideIonicAngular,
 } from '@ionic/angular/standalone';
 import { addIcons } from 'ionicons';
-import { defineCustomElements as defineIonIcons } from 'ionicons/loader';
+import { defineCustomElements as defineIonIcons } from 'ionicons/dist/loader';
 import {
   calendarOutline,
   helpOutline,


### PR DESCRIPTION
## Summary
- correct `ionicons/loader` import path

## Testing
- `npm run lint`
- `npm run build` *(fails: Inlining of fonts failed due to network restrictions)*
- `npm test` *(fails: Chrome not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d220235bc8327a3b031a7c07e9261