### PR TITLE
Revert duplicate header removal

### DIFF
--- a/src/app/academic-progress/academic-progress.page.html
+++ b/src/app/academic-progress/academic-progress.page.html
@@ -1,4 +1,9 @@
 
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Academic Progress</ion-title>
+    </ion-toolbar>
+  </ion-header>
 
   <ion-content>
   <ion-list>

--- a/src/app/academic-progress/academic-progress.page.ts
+++ b/src/app/academic-progress/academic-progress.page.ts
@@ -2,9 +2,9 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import {
-  
-  
-  
+  IonHeader,
+  IonToolbar,
+  IonTitle,
   IonContent,
   IonItem,
   IonLabel,
@@ -23,6 +23,9 @@ import { ToastController } from '@ionic/angular';
   imports: [
     CommonModule,
     FormsModule,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
     IonContent,
     IonItem,
     IonLabel,
@@ -30,6 +33,7 @@ import { ToastController } from '@ionic/angular';
     IonList,
     IonButton,
     IonCheckbox,
+
   ],
   templateUrl: './academic-progress.page.html',
   styleUrls: ['./academic-progress.page.scss'],

--- a/src/app/bible-quiz/bible-quiz.page.html
+++ b/src/app/bible-quiz/bible-quiz.page.html
@@ -1,4 +1,9 @@
 
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Bible Quiz</ion-title>
+    </ion-toolbar>
+  </ion-header>
 
   <ion-content>
   <ion-spinner *ngIf="loading" name="dots" class="center-spinner"></ion-spinner>

--- a/src/app/bible-quiz/bible-quiz.page.ts
+++ b/src/app/bible-quiz/bible-quiz.page.ts
@@ -2,9 +2,9 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import {
-  
-  
-  
+  IonHeader,
+  IonToolbar,
+  IonTitle,
   IonContent,
   IonItem,
   IonLabel,
@@ -26,6 +26,9 @@ import { ToastController } from '@ionic/angular';
   imports: [
     CommonModule,
     FormsModule,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
     IonContent,
     IonItem,
     IonLabel,

--- a/src/app/check-in/check-in.page.html
+++ b/src/app/check-in/check-in.page.html
@@ -1,4 +1,9 @@
 
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Daily Check-In</ion-title>
+    </ion-toolbar>
+  </ion-header>
 
   <ion-content>
   <ion-list>

--- a/src/app/check-in/check-in.page.ts
+++ b/src/app/check-in/check-in.page.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import {  IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonTextarea, IonSegment, IonSegmentButton, IonCheckbox } from '@ionic/angular/standalone';
+import {  IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonTextarea, IonSegment, IonSegmentButton, IonCheckbox } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { ToastController } from '@ionic/angular';
 import { DailyCheckin } from '../models/daily-checkin';
@@ -12,6 +12,9 @@ import { DailyCheckin } from '../models/daily-checkin';
   imports: [
     CommonModule,
     FormsModule,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
     IonContent,
     IonInput,
     IonItem,

--- a/src/app/child-account/child-account.page.html
+++ b/src/app/child-account/child-account.page.html
@@ -1,4 +1,9 @@
 
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Create Child Account</ion-title>
+    </ion-toolbar>
+  </ion-header>
 
   <ion-content class="ion-padding">
   <ion-list>

--- a/src/app/child-account/child-account.page.ts
+++ b/src/app/child-account/child-account.page.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { IonContent, IonInput, IonItem, IonLabel, IonButton, IonList } from '@ionic/angular/standalone';
+import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
 import { ToastController } from '@ionic/angular';
@@ -12,6 +12,9 @@ import { ToastController } from '@ionic/angular';
   imports: [
     CommonModule,
     FormsModule,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
     IonContent,
     IonInput,
     IonItem,

--- a/src/app/essay-tracker/essay-tracker.page.html
+++ b/src/app/essay-tracker/essay-tracker.page.html
@@ -1,4 +1,9 @@
 
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Essay Tracker</ion-title>
+    </ion-toolbar>
+  </ion-header>
 
   <ion-content>
   <ion-list>

--- a/src/app/essay-tracker/essay-tracker.page.ts
+++ b/src/app/essay-tracker/essay-tracker.page.ts
@@ -3,9 +3,9 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import {
 
-  
-  
-  
+  IonHeader,
+  IonToolbar,
+  IonTitle,
   IonContent,
   IonItem,
   IonLabel,
@@ -24,8 +24,12 @@ import { ToastController } from '@ionic/angular';
   selector: 'app-essay-tracker',
   standalone: true,
   imports: [
+    
     CommonModule,
     FormsModule,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
     IonContent,
     IonItem,
     IonLabel,

--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -1,3 +1,10 @@
+  <ion-header [translucent]="true">
+    <ion-toolbar>
+      <ion-title>
+        Grounded and Fruitful
+      </ion-title>
+    </ion-toolbar>
+  </ion-header>
 
   <ion-content [fullscreen]="true">
 

--- a/src/app/home/home.page.ts
+++ b/src/app/home/home.page.ts
@@ -1,9 +1,9 @@
 import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import {
-  
-  
-  
+  IonHeader,
+  IonToolbar,
+  IonTitle,
   IonContent,
   IonButton,
   IonGrid,
@@ -19,6 +19,9 @@ import { NgIf } from '@angular/common';
   styleUrls: ['home.page.scss'],
   standalone: true,
   imports: [
+    IonHeader,
+    IonToolbar,
+    IonTitle,
     IonContent,
     IonButton,
     IonGrid,

--- a/src/app/leaderboard/leaderboard.page.html
+++ b/src/app/leaderboard/leaderboard.page.html
@@ -1,4 +1,9 @@
 
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Leaderboard</ion-title>
+    </ion-toolbar>
+  </ion-header>
 
   <ion-content>
   <ion-list>

--- a/src/app/leaderboard/leaderboard.page.ts
+++ b/src/app/leaderboard/leaderboard.page.ts
@@ -2,9 +2,9 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {
   
-  
-  
-  
+  IonHeader,
+  IonToolbar,
+  IonTitle,
   IonContent,
   IonList,
   IonItem,
@@ -17,7 +17,11 @@ import { LeaderboardEntry } from '../models/user-stats';
   selector: 'app-leaderboard',
   standalone: true,
   imports: [
+    
     CommonModule,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
     IonContent,
     IonList,
     IonItem,

--- a/src/app/mental-status/mental-status.page.html
+++ b/src/app/mental-status/mental-status.page.html
@@ -1,4 +1,9 @@
 
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Mental & Emotional Status</ion-title>
+    </ion-toolbar>
+  </ion-header>
 
   <ion-content>
   <ion-list>

--- a/src/app/mental-status/mental-status.page.ts
+++ b/src/app/mental-status/mental-status.page.ts
@@ -3,9 +3,9 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import {
 
-  
-  
-  
+  IonHeader,
+  IonToolbar,
+  IonTitle,
   IonContent,
   IonItem,
   IonLabel,
@@ -23,11 +23,16 @@ import { ToastController } from '@ionic/angular';
   selector: 'app-mental-status',
   standalone: true,
   imports: [
+    
     CommonModule,
     FormsModule,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
     IonContent,
     IonItem,
     IonLabel,
+
     IonList,
     IonButton,
     IonCheckbox,

--- a/src/app/mentor-record/mentor-record.page.html
+++ b/src/app/mentor-record/mentor-record.page.html
@@ -1,4 +1,9 @@
 <div class="ion-page">
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Mentor Board</ion-title>
+    </ion-toolbar>
+  </ion-header>
   <ion-content>
     <ion-list>
       <ion-item *ngFor="let rec of records">

--- a/src/app/mentor-record/mentor-record.page.ts
+++ b/src/app/mentor-record/mentor-record.page.ts
@@ -1,9 +1,9 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {
-  
-  
-  
+  IonHeader,
+  IonToolbar,
+  IonTitle,
   IonContent,
   IonList,
   IonItem,
@@ -18,6 +18,9 @@ import { MentorRecord } from '../models/mentor-record';
   standalone: true,
   imports: [
     CommonModule,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
     IonContent,
     IonList,
     IonItem,

--- a/src/app/project-tracker/project-tracker.page.html
+++ b/src/app/project-tracker/project-tracker.page.html
@@ -1,4 +1,9 @@
 <div class="ion-page">
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Project Tracker</ion-title>
+    </ion-toolbar>
+  </ion-header>
 
   <ion-content>
     <ion-list>

--- a/src/app/project-tracker/project-tracker.page.ts
+++ b/src/app/project-tracker/project-tracker.page.ts
@@ -2,9 +2,9 @@ import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule,ReactiveFormsModule } from '@angular/forms';
 import {
-  
-  
-  
+  IonHeader,
+  IonToolbar,
+  IonTitle,
   IonContent,
   IonItem,
   IonLabel,
@@ -26,6 +26,9 @@ import { ToastController } from '@ionic/angular';
   imports: [
     CommonModule,
     FormsModule,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
     IonContent,
     IonItem,
     IonLabel,

--- a/src/app/quiz-history/quiz-history.page.html
+++ b/src/app/quiz-history/quiz-history.page.html
@@ -1,3 +1,8 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Quiz History</ion-title>
+  </ion-toolbar>
+</ion-header>
 
 <ion-content>
   <div class="ion-padding">

--- a/src/app/quiz-history/quiz-history.page.ts
+++ b/src/app/quiz-history/quiz-history.page.ts
@@ -1,9 +1,9 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {
-  
-  
-  
+  IonHeader,
+  IonToolbar,
+  IonTitle,
   IonContent,
   IonList,
   IonItem,
@@ -19,6 +19,9 @@ import { BibleQuizResult } from '../models/bible-quiz';
   standalone: true,
   imports: [
     CommonModule,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
     IonContent,
     IonList,
     IonItem,

--- a/src/app/reward-center/reward-center.page.html
+++ b/src/app/reward-center/reward-center.page.html
@@ -1,3 +1,8 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Reward Center</ion-title>
+  </ion-toolbar>
+</ion-header>
 
 <ion-content>
   <div class="stats" *ngIf="stats">

--- a/src/app/reward-center/reward-center.page.ts
+++ b/src/app/reward-center/reward-center.page.ts
@@ -1,9 +1,9 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {
-  
-  
-  
+  IonHeader,
+  IonToolbar,
+  IonTitle,
   IonContent,
   IonList,
   IonItem,
@@ -25,6 +25,9 @@ import { firstValueFrom } from 'rxjs';
   standalone: true,
   imports: [
     CommonModule,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
     IonContent,
     IonList,
     IonItem,


### PR DESCRIPTION
## Summary
- revert merge commit that removed duplicate headers when removing duplicate menu items

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_688d333a367083278ea514877bee914e