### PR TITLE
feat: add group selection page

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -71,9 +71,15 @@ export const routes: Routes = [
         data: { title: 'Create Child Account' },
       },
       {
+        path: 'group',
+        loadComponent: () =>
+          import('./group/group.page').then((m) => m.GroupPage),
+        data: { title: 'Group Selection' },
+      },
+      {
         path: 'leaderboard',
         loadComponent: () =>
-      import('./leaderboard/leaderboard.page').then((m) => m.LeaderboardPage),
+          import('./leaderboard/leaderboard.page').then((m) => m.LeaderboardPage),
         data: { title: 'Leaderboard' },
       },
       {

--- a/src/app/group/group.page.html
+++ b/src/app/group/group.page.html
@@ -1,0 +1,45 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Groups</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+  <ion-list>
+    <ion-item>
+      <ion-label>Mentor</ion-label>
+      <ion-select [(ngModel)]="selectedMentor" placeholder="Select Mentor">
+        <ion-select-option *ngFor="let m of mentors" [value]="m.id">
+          {{ m.name }}
+        </ion-select-option>
+      </ion-select>
+    </ion-item>
+  </ion-list>
+
+  <ion-item>
+    <ion-label>Group Type</ion-label>
+    <ion-select [(ngModel)]="groupType">
+      <ion-select-option value="school">School Based</ion-select-option>
+      <ion-select-option value="neighbourhood">Neighbourhood Based</ion-select-option>
+      <ion-select-option value="family">Family Based</ion-select-option>
+      <ion-select-option value="church">Church Based</ion-select-option>
+      <ion-select-option value="random">Random</ion-select-option>
+    </ion-select>
+  </ion-item>
+  <ion-item>
+    <ion-label position="stacked">Age Group</ion-label>
+    <ion-input [(ngModel)]="ageGroup"></ion-input>
+  </ion-item>
+  <ion-button expand="block" (click)="createGroup()">Create Group</ion-button>
+
+  <ion-list>
+    <ion-item *ngFor="let g of groups">
+      <ion-label>
+        {{ g.type }} - Age: {{ g.ageGroup }} ({{ g.members.length }}/5)
+      </ion-label>
+      <ion-button slot="end" (click)="joinGroup(g)" [disabled]="g.members.length >= 5">
+        Join
+      </ion-button>
+    </ion-item>
+  </ion-list>
+</ion-content>

--- a/src/app/group/group.page.scss
+++ b/src/app/group/group.page.scss
@@ -1,0 +1,1 @@
+/* Add any custom styling for group page here */

--- a/src/app/group/group.page.spec.ts
+++ b/src/app/group/group.page.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { GroupPage } from './group.page';
+
+describe('GroupPage', () => {
+  let component: GroupPage;
+  let fixture: ComponentFixture<GroupPage>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [GroupPage],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(GroupPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/group/group.page.ts
+++ b/src/app/group/group.page.ts
@@ -1,0 +1,86 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonContent,
+  IonList,
+  IonItem,
+  IonLabel,
+  IonButton,
+  IonSelect,
+  IonSelectOption,
+  IonInput,
+} from '@ionic/angular/standalone';
+import { FormsModule } from '@angular/forms';
+import { Group, GroupType } from '../models/group';
+import { GroupService } from '../services/group.service';
+import { MentorApiService } from '../services/mentor-api.service';
+import { FirebaseService } from '../services/firebase.service';
+
+interface MentorOption {
+  id: string;
+  name: string;
+}
+
+@Component({
+  selector: 'app-group',
+  templateUrl: './group.page.html',
+  styleUrls: ['./group.page.scss'],
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
+    IonContent,
+    IonList,
+    IonItem,
+    IonLabel,
+    IonButton,
+    IonSelect,
+    IonSelectOption,
+    IonInput,
+  ],
+})
+export class GroupPage {
+  groupType: GroupType = 'school';
+  ageGroup = '';
+  selectedMentor = '';
+  mentors: MentorOption[] = [
+    { id: 'mentor1', name: 'Mentor 1' },
+    { id: 'mentor2', name: 'Mentor 2' },
+  ];
+
+  constructor(
+    private groupSvc: GroupService,
+    private mentorApi: MentorApiService,
+    private fb: FirebaseService
+  ) {}
+
+  get groups(): Group[] {
+    return this.groupSvc.getGroups();
+  }
+
+  createGroup() {
+    if (this.ageGroup.trim()) {
+      this.groupSvc.createGroup(this.groupType, this.ageGroup);
+      this.ageGroup = '';
+    }
+  }
+
+  joinGroup(group: Group) {
+    const childId = this.fb.auth.currentUser?.uid;
+    if (!childId) {
+      return;
+    }
+    if (this.selectedMentor) {
+      this.mentorApi
+        .assignMentor({ mentorId: this.selectedMentor, childId })
+        .subscribe();
+    }
+    this.groupSvc.addMember(group.id, childId);
+  }
+}

--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -32,6 +32,9 @@
         <ion-col size="6">
           <ion-button class="tile-button" routerLink="/tabs/mentor-record" expand="block">Mentor Board</ion-button>
         </ion-col>
+        <ion-col size="6">
+          <ion-button class="tile-button" routerLink="/tabs/group" expand="block">Groups</ion-button>
+        </ion-col>
       </ion-row>
 
       <!-- Child Buttons -->

--- a/src/app/models/group.ts
+++ b/src/app/models/group.ts
@@ -1,0 +1,14 @@
+export type GroupType =
+  | 'school'
+  | 'neighbourhood'
+  | 'family'
+  | 'church'
+  | 'random';
+
+export interface Group {
+  id: string;
+  type: GroupType;
+  ageGroup: string;
+  members: string[];
+  mentorId?: string;
+}

--- a/src/app/services/group.service.ts
+++ b/src/app/services/group.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import { Group, GroupType } from '../models/group';
+
+@Injectable({ providedIn: 'root' })
+export class GroupService {
+  private groups: Group[] = [];
+
+  getGroups(): Group[] {
+    return this.groups;
+  }
+
+  createGroup(type: GroupType, ageGroup: string): Group {
+    const group: Group = {
+      id: crypto.randomUUID(),
+      type,
+      ageGroup,
+      members: [],
+    };
+    this.groups.push(group);
+    return group;
+  }
+
+  addMember(groupId: string, childId: string): boolean {
+    const group = this.groups.find((g) => g.id === groupId);
+    if (!group) {
+      return false;
+    }
+    if (group.members.length >= 5) {
+      return false;
+    }
+    if (!group.members.includes(childId)) {
+      group.members.push(childId);
+    }
+    return true;
+  }
+}


### PR DESCRIPTION
## Summary
- add group model and service with max five members per group
- build group page letting parents pick group type, age range, and mentor
- expose group selection from home and routing

## Testing
- `npm run lint`
- `npm test -- --watch=false --browsers=ChromeHeadless --no-progress` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_688e6e91d5548327a87481ac2aa95fdc