### PR TITLE
feat: add mentor role option

### DIFF
--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -37,6 +37,16 @@
         </ion-col>
       </ion-row>
 
+      <!-- Mentor Buttons -->
+      <ion-row *ngIf="role === 'mentor'">
+        <ion-col size="6">
+          <ion-button class="tile-button" routerLink="/tabs/mentor-record" expand="block">Mentor Board</ion-button>
+        </ion-col>
+        <ion-col size="6">
+          <ion-button class="tile-button" routerLink="/tabs/group" expand="block">Groups</ion-button>
+        </ion-col>
+      </ion-row>
+
       <!-- Child Buttons -->
       <ng-container *ngIf="role === 'child'">
         <ion-row>

--- a/src/app/login/login.page.html
+++ b/src/app/login/login.page.html
@@ -20,6 +20,7 @@
       <ion-select [(ngModel)]="selectedRole">
         <ion-select-option value="parent">Parent</ion-select-option>
         <ion-select-option value="child">Child</ion-select-option>
+        <ion-select-option value="mentor">Mentor</ion-select-option>
       </ion-select>
     </ion-item>
   </ion-list>

--- a/src/app/tabs/tabs.page.html
+++ b/src/app/tabs/tabs.page.html
@@ -22,7 +22,11 @@
       <ion-icon name="chatbubble-ellipses-outline"></ion-icon>
       <ion-label>Mentor</ion-label>
     </ion-tab-button>
-    <ion-tab-button tab="reward-center" href="/tabs/reward-center">
+    <ion-tab-button
+      tab="reward-center"
+      href="/tabs/reward-center"
+      *ngIf="role !== 'mentor'"
+    >
       <ion-icon name="gift-outline"></ion-icon>
       <ion-label>Rewards</ion-label>
     </ion-tab-button>


### PR DESCRIPTION
## Summary
- add Mentor role to login role selector
- display mentor-specific tiles on home page
- hide Reward Center tab for mentors

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_688e77aa35c08327a648260dd128f465