### PR TITLE
feat: update document title on navigation

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -14,9 +14,11 @@ import {
   IonLabel,
   
 } from '@ionic/angular/standalone';
-import { Router, RouterLink } from '@angular/router';
+import { Router, RouterLink, ActivatedRoute, NavigationEnd } from '@angular/router';
 import { FirebaseService } from './services/firebase.service';
 import { RoleService } from './services/role.service';
+import { Title } from '@angular/platform-browser';
+import { filter } from 'rxjs/operators';
 
 @Component({
   selector: 'app-root',
@@ -40,7 +42,13 @@ import { RoleService } from './services/role.service';
 export class AppComponent {
   loggedIn = false;
 
-  constructor(private router: Router, private fb: FirebaseService, private roleSvc: RoleService) {
+  constructor(
+    private router: Router,
+    private fb: FirebaseService,
+    private roleSvc: RoleService,
+    private title: Title,
+    private route: ActivatedRoute
+  ) {
     this.fb.auth.onAuthStateChanged((user) => {
       this.loggedIn = !!user;
       const url = this.router.url;
@@ -52,6 +60,18 @@ export class AppComponent {
         this.router.navigateByUrl('/tabs');
       }
     });
+
+    const appTitle = 'Grounded and Fruitful';
+    this.router.events
+      .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd))
+      .subscribe(() => {
+        let child = this.route.firstChild;
+        while (child && child.firstChild) {
+          child = child.firstChild;
+        }
+        const routeTitle = child?.snapshot.data['title'];
+        this.title.setTitle(routeTitle ? `${routeTitle} | ${appTitle}` : appTitle);
+      });
   }
 
   logout() {

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -108,11 +108,13 @@ export const routes: Routes = [
   {
     path: 'login',
     loadComponent: () => import('./login/login.page').then((m) => m.LoginPage),
+    data: { title: 'Login' },
   },
   {
     path: 'register',
     loadComponent: () =>
       import('./register/register.page').then((m) => m.RegisterPage),
+    data: { title: 'Register' },
   },
   {
     path: '',


### PR DESCRIPTION
## Summary
- update app component to set document title based on current route
- add title metadata for login and register routes

## Testing
- `npm run lint`
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_688e7c38bd888327b1b93dd3b43647b3