### PR TITLE
Sync document title with active tab

### DIFF
--- a/src/app/tabs/tabs.page.html
+++ b/src/app/tabs/tabs.page.html
@@ -3,7 +3,7 @@
     <ion-buttons slot="start">
       <ion-menu-button></ion-menu-button>
     </ion-buttons>
-    <ion-title>{{ pageTitle }}</ion-title>
+    <ion-title>{{ appTitle }}</ion-title>
     <ion-buttons slot="end">
       <ion-button (click)="logout()">
         <ion-icon name="log-out-outline"></ion-icon>

--- a/src/app/tabs/tabs.page.ts
+++ b/src/app/tabs/tabs.page.ts
@@ -20,6 +20,7 @@ import { Router, ActivatedRoute, NavigationEnd, RouterLink } from '@angular/rout
 import { RoleService } from '../services/role.service';
 import { FirebaseService } from '../services/firebase.service';
 import { filter } from 'rxjs/operators';
+import { Title } from '@angular/platform-browser';
 
 @Component({
   selector: 'app-tabs',
@@ -44,13 +45,14 @@ import { filter } from 'rxjs/operators';
 })
 export class TabsPage {
   loggedIn = false;
-  pageTitle = 'Grounded and Fruitful';
+  appTitle = 'Grounded and Fruitful';
 
   constructor(
     private router: Router,
     private route: ActivatedRoute,
     public roleSvc: RoleService,
-    private fb: FirebaseService
+    private fb: FirebaseService,
+    private title: Title,
   ) {
     // Monitor Firebase Auth State
     this.fb.auth.onAuthStateChanged((user) => {
@@ -73,7 +75,10 @@ export class TabsPage {
         while (child.firstChild) {
           child = child.firstChild;
         }
-        this.pageTitle = child.snapshot.data['title'] || 'Grounded and Fruitful';
+        const baseTitle = 'Grounded and Fruitful';
+        const routeTitle = child.snapshot.data['title'];
+        this.appTitle = routeTitle || baseTitle;
+        this.title.setTitle(routeTitle ? `${routeTitle} | ${baseTitle}` : baseTitle);
       });
   }
 


### PR DESCRIPTION
## Summary
- sync browser page title with current tab by using Angular Title service
- display the updated appTitle in the tabs header

## Testing
- `npm run lint`
- `npm test --watch=false --browsers=ChromeHeadless --progress=false` *(fails: No binary for ChromeHeadless browser on your platform; attempted `apt-get update` but repositories were not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688e91935994832796f5b99241834ee1