### PR TITLE
Fix tab header title disappearing on refresh

### DIFF
--- a/src/app/tabs/tabs.page.ts
+++ b/src/app/tabs/tabs.page.ts
@@ -12,9 +12,6 @@ import {
   IonToolbar,
   IonHeader,
   IonMenuButton,
-  IonMenuToggle,
-  IonMenu,
-  IonContent,
 } from '@ionic/angular/standalone';
 import { Router, ActivatedRoute, NavigationEnd, RouterLink } from '@angular/router';
 import { RoleService } from '../services/role.service';
@@ -49,7 +46,6 @@ export class TabsPage {
 
   constructor(
     private router: Router,
-    private route: ActivatedRoute,
     public roleSvc: RoleService,
     private fb: FirebaseService,
     private title: Title,
@@ -71,7 +67,7 @@ export class TabsPage {
     this.router.events
       .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd))
       .subscribe(() => {
-        let child = this.route;
+        let child: ActivatedRoute = this.router.routerState.root;
         while (child.firstChild) {
           child = child.firstChild;
         }


### PR DESCRIPTION
## Summary
- ensure tab header title uses the deepest child route so it persists on refresh
- clean up unused Ionic imports in TabsPage

## Testing
- `npm run lint`
- `npm test -- --watch=false --browsers=ChromeHeadless --no-progress` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_688ebfe8251c83279e4202be202f5816