### PR TITLE
Restrict child accounts to child role

### DIFF
--- a/src/app/login/login.page.ts
+++ b/src/app/login/login.page.ts
@@ -47,7 +47,23 @@ export class LoginPage {
   async login() {
     try {
       await this.fb.login(this.form.email, this.form.password);
-      this.roleSvc.setRole(this.selectedRole);
+      const user = this.fb.auth.currentUser;
+      const isChild = user
+        ? await this.fb.isChildAccount(user.uid)
+        : false;
+      if (isChild && this.selectedRole !== 'child') {
+        const errToast = await this.toastCtrl.create({
+          message: 'Child accounts can only use the child role',
+          duration: 1500,
+          position: 'bottom',
+          color: 'danger',
+        });
+        await errToast.present();
+        await this.fb.logout();
+        return;
+      }
+      const role = isChild ? 'child' : this.selectedRole;
+      this.roleSvc.setRole(role);
       const toast = await this.toastCtrl.create({
         message: 'Logged in',
         duration: 1500,
@@ -69,7 +85,23 @@ export class LoginPage {
   async loginWithGoogle() {
     try {
       await this.fb.loginWithGoogle();
-      this.roleSvc.setRole(this.selectedRole);
+      const user = this.fb.auth.currentUser;
+      const isChild = user
+        ? await this.fb.isChildAccount(user.uid)
+        : false;
+      if (isChild && this.selectedRole !== 'child') {
+        const errToast = await this.toastCtrl.create({
+          message: 'Child accounts can only use the child role',
+          duration: 1500,
+          position: 'bottom',
+          color: 'danger',
+        });
+        await errToast.present();
+        await this.fb.logout();
+        return;
+      }
+      const role = isChild ? 'child' : this.selectedRole;
+      this.roleSvc.setRole(role);
       const toast = await this.toastCtrl.create({
         message: 'Logged in with Google',
         duration: 1500,

--- a/src/app/services/firebase.service.ts
+++ b/src/app/services/firebase.service.ts
@@ -91,6 +91,11 @@ export class FirebaseService {
     return (snap.docs[0].data() as ParentChildLink).parentId || null;
   }
 
+  async isChildAccount(userId: string): Promise<boolean> {
+    const profile = await getDoc(doc(this.db, 'childProfiles', userId));
+    return profile.exists();
+  }
+
   async saveDailyCheckin(data: DailyCheckin) {
     const docRef = await addDoc(collection(this.db, 'dailyCheckins'), data);
     if (data.childId) {


### PR DESCRIPTION
## Summary
- prevent child accounts from logging in as parent or mentor roles
- add helper to detect child accounts via Firestore

## Testing
- `npm test -- --watch=false --progress=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ee7d70b508327847ce14b26e15a53