### PR TITLE
feat: handle child account creation errors

### DIFF
--- a/src/app/child-account/child-account.page.ts
+++ b/src/app/child-account/child-account.page.ts
@@ -1,7 +1,17 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList } from '@ionic/angular/standalone';
+import {
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonContent,
+  IonInput,
+  IonItem,
+  IonLabel,
+  IonButton,
+  IonList,
+} from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
 import { ToastController } from '@ionic/angular';
@@ -39,21 +49,37 @@ export class ChildAccountPage {
     if (!user) {
       return;
     }
-    if (this.form.age === null) {
+
+    const { email, password, age } = this.form;
+    if (!email || !password || age === null) {
+      const toast = await this.toastCtrl.create({
+        message: 'All fields are required',
+        duration: 1500,
+        position: 'bottom',
+      });
+      await toast.present();
       return;
     }
-    await this.fb.createChildAccount(
-      this.form.email,
-      this.form.password,
-      user.uid,
-      this.form.age
-    );
-    const toast = await this.toastCtrl.create({
-      message: 'Child account created',
-      duration: 1500,
-      position: 'bottom',
-    });
-    await toast.present();
-    this.router.navigateByUrl('/tabs/home');
+
+    try {
+      await this.fb.createChildAccount(email, password, user.uid, age);
+      const toast = await this.toastCtrl.create({
+        message: 'Child account created',
+        duration: 1500,
+        position: 'bottom',
+      });
+      await toast.present();
+      this.router.navigateByUrl('/tabs/home');
+    } catch (err) {
+      const toast = await this.toastCtrl.create({
+        message:
+          err instanceof Error
+            ? err.message
+            : 'Unable to create child account',
+        duration: 2000,
+        position: 'bottom',
+      });
+      await toast.present();
+    }
   }
 }


### PR DESCRIPTION
## Summary
- validate child account form entries
- surface Firebase errors when child account creation fails

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: process exited without output)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688efa47c2a883279fa2edfd82543ca6