### PR TITLE
Revert child login parental oversight

### DIFF
--- a/src/app/login/login.page.ts
+++ b/src/app/login/login.page.ts
@@ -47,23 +47,7 @@ export class LoginPage {
   async login() {
     try {
       await this.fb.login(this.form.email, this.form.password);
-      const user = this.fb.auth.currentUser;
-      const isChild = user
-        ? await this.fb.isChildAccount(user.uid)
-        : false;
-      if (isChild && this.selectedRole !== 'child') {
-        const errToast = await this.toastCtrl.create({
-          message: 'Child accounts can only use the child role',
-          duration: 1500,
-          position: 'bottom',
-          color: 'danger',
-        });
-        await errToast.present();
-        await this.fb.logout();
-        return;
-      }
-      const role = isChild ? 'child' : this.selectedRole;
-      this.roleSvc.setRole(role);
+      this.roleSvc.setRole(this.selectedRole);
       const toast = await this.toastCtrl.create({
         message: 'Logged in',
         duration: 1500,
@@ -85,23 +69,7 @@ export class LoginPage {
   async loginWithGoogle() {
     try {
       await this.fb.loginWithGoogle();
-      const user = this.fb.auth.currentUser;
-      const isChild = user
-        ? await this.fb.isChildAccount(user.uid)
-        : false;
-      if (isChild && this.selectedRole !== 'child') {
-        const errToast = await this.toastCtrl.create({
-          message: 'Child accounts can only use the child role',
-          duration: 1500,
-          position: 'bottom',
-          color: 'danger',
-        });
-        await errToast.present();
-        await this.fb.logout();
-        return;
-      }
-      const role = isChild ? 'child' : this.selectedRole;
-      this.roleSvc.setRole(role);
+      this.roleSvc.setRole(this.selectedRole);
       const toast = await this.toastCtrl.create({
         message: 'Logged in with Google',
         duration: 1500,

--- a/src/app/services/firebase.service.ts
+++ b/src/app/services/firebase.service.ts
@@ -91,11 +91,6 @@ export class FirebaseService {
     return (snap.docs[0].data() as ParentChildLink).parentId || null;
   }
 
-  async isChildAccount(userId: string): Promise<boolean> {
-    const profile = await getDoc(doc(this.db, 'childProfiles', userId));
-    return profile.exists();
-  }
-
   async saveDailyCheckin(data: DailyCheckin) {
     const docRef = await addDoc(collection(this.db, 'dailyCheckins'), data);
     if (data.childId) {


### PR DESCRIPTION
## Summary
- Revert PR #140 adding child-only login restrictions and parental oversight.

## Testing
- `CI=true npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f80a44cac8327a49d08d7bc61e012