### PR TITLE
fix: ensure custom color scheme overrides dark palette

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -42,7 +42,6 @@
               "node_modules/@ionic/angular/css/text-transformation.css",
               "node_modules/@ionic/angular/css/flex-utils.css",
               "node_modules/@ionic/angular/css/display.css",
-              "src/theme/variables.scss",
               "src/global.scss"
             ],
             "scripts": [],
@@ -130,7 +129,6 @@
               "node_modules/@ionic/angular/css/text-transformation.css",
               "node_modules/@ionic/angular/css/flex-utils.css",
               "node_modules/@ionic/angular/css/display.css",
-              "src/theme/variables.scss",
               "src/global.scss"
             ],
             "scripts": []

--- a/src/global.scss
+++ b/src/global.scss
@@ -35,6 +35,7 @@
 /* @import "@ionic/angular/css/palettes/dark.always.css"; */
 /* @import "@ionic/angular/css/palettes/dark.class.css"; */
 @import '@ionic/angular/css/palettes/dark.system.css';
+@import './theme/variables.scss';
 // ion-toolbar {
 //   --background: var(--ion-color-primary);
 //   --color: var(--ion-color-light);


### PR DESCRIPTION
## Summary
- import custom variables after Ionic dark palette so custom colors show
- remove extra variables.scss entries from Angular CLI styles

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68903bacbe5c8327b37681c801303cb3