### PR TITLE
fix: update mentor records endpoint

### DIFF
--- a/src/app/services/mentor-record-api.service.ts
+++ b/src/app/services/mentor-record-api.service.ts
@@ -9,7 +9,7 @@ import { MentorRecord } from '../models/mentor-record';
 @Injectable({ providedIn: 'root' })
 export class MentorRecordApiService {
   private apiEnabled = !!environment.apiUrl;
-  private readonly baseUrl = `${environment.apiUrl}/api/mentors`;
+  private readonly baseUrl = `${environment.apiUrl}/api/mentor-records`;
 
   constructor(private http: HttpClient, private fb: FirebaseService) {}
 
@@ -18,7 +18,7 @@ export class MentorRecordApiService {
       return from(this.fb.getMentorRecords(childId));
     }
     return this.http
-      .get<MentorRecord[]>(`${this.baseUrl}/${childId}/records`)
+      .get<MentorRecord[]>(`${this.baseUrl}/${childId}`)
       .pipe(catchError(() => from(this.fb.getMentorRecords(childId))));
   }
 }


### PR DESCRIPTION
## Summary
- point mentor record API service to new `/api/mentor-records/:childId` endpoint

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689245be9e008327ac40fb6cf733d795