### PR TITLE
Align mentor record frontend with backend

### DIFF
--- a/src/app/mentor-record/mentor-record.page.html
+++ b/src/app/mentor-record/mentor-record.page.html
@@ -8,12 +8,10 @@
     <ion-list>
       <ion-item *ngFor="let rec of records">
         <ion-label>
-          <h2>{{ rec.title }}</h2>
-          <p>{{ rec.outline }}</p>
+          <p>{{ rec.notes }}</p>
           <p>Progress: {{ rec.progress }}%</p>
           <p>Due: {{ rec.dueDate | date }}</p>
           <p>Time remaining: {{ getTimeRemaining(rec.dueDate) }}</p>
-          <p *ngIf="rec.encouragement">{{ rec.encouragement }}</p>
         </ion-label>
       </ion-item>
     </ion-list>

--- a/src/app/models/mentor-record.ts
+++ b/src/app/models/mentor-record.ts
@@ -1,10 +1,16 @@
 export interface MentorRecord {
-  title: string;
-  outline: string;
-  progress: number;
-  dueDate: string;
-  encouragement?: string;
+  /** Unique document identifier */
+  id?: string;
+  /** Child linked to the record */
   childId?: string | null;
+  /** Mentor who created the record */
   mentorId?: string | null;
-  updatedAt: string;
+  /** Mentor notes for the child */
+  notes: string;
+  /** Completion progress as a percentage */
+  progress: number;
+  /** Due date for the task */
+  dueDate: string;
+  /** Server timestamp for creation */
+  created?: string;
 }

--- a/src/app/services/mentor-record-api.service.ts
+++ b/src/app/services/mentor-record-api.service.ts
@@ -9,7 +9,7 @@ import { MentorRecord } from '../models/mentor-record';
 @Injectable({ providedIn: 'root' })
 export class MentorRecordApiService {
   private apiEnabled = !!environment.apiUrl;
-  private readonly baseUrl = `${environment.apiUrl}/api/mentor-records`;
+  private readonly baseUrl = `${environment.apiUrl}/api/mentors`;
 
   constructor(private http: HttpClient, private fb: FirebaseService) {}
 
@@ -18,7 +18,16 @@ export class MentorRecordApiService {
       return from(this.fb.getMentorRecords(childId));
     }
     return this.http
-      .get<MentorRecord[]>(`${this.baseUrl}/${childId}`)
+      .get<MentorRecord[]>(`${this.baseUrl}/${childId}/records`)
       .pipe(catchError(() => from(this.fb.getMentorRecords(childId))));
+  }
+
+  createRecord(record: MentorRecord): Observable<unknown> {
+    if (!this.apiEnabled) {
+      return from(this.fb.saveMentorRecord(record));
+    }
+    return this.http
+      .post(`${this.baseUrl}/records`, record)
+      .pipe(catchError(() => from(this.fb.saveMentorRecord(record))));
   }
 }


### PR DESCRIPTION
## Summary
- Align mentor record model with backend fields
- Point mentor record service to /api/mentors endpoints and add create method
- Show mentor record notes and due dates on mentor board

## Testing
- `npm run lint`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*
- `sudo apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68925259772c8327b04f8735e8d8ca65