### PR TITLE
feat: show message for empty mentor records

### DIFF
--- a/src/app/mentor-record/mentor-record.page.html
+++ b/src/app/mentor-record/mentor-record.page.html
@@ -14,6 +14,9 @@
           <p>Time remaining: {{ getTimeRemaining(rec.dueDate) }}</p>
         </ion-label>
       </ion-item>
+      <ion-item *ngIf="records.length === 0">
+        <ion-label>No mentor records found.</ion-label>
+      </ion-item>
     </ion-list>
   </ion-content>
 </div>


### PR DESCRIPTION
## Summary
- show placeholder message when no mentor records are available

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68926c39269c832785ebc8d00a41d055