### PR TITLE
feat: add admin mentor assignment page

### DIFF
--- a/src/app/admin/admin.page.html
+++ b/src/app/admin/admin.page.html
@@ -1,0 +1,18 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Assign Mentor</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content class="ion-padding">
+  <ion-item>
+    <ion-label position="stacked">Mentor ID</ion-label>
+    <ion-input [(ngModel)]="mentorId"></ion-input>
+  </ion-item>
+  <ion-item>
+    <ion-label position="stacked">Child ID</ion-label>
+    <ion-input [(ngModel)]="childId"></ion-input>
+  </ion-item>
+  <ion-button expand="block" (click)="assign()">Assign</ion-button>
+</ion-content>
+

--- a/src/app/admin/admin.page.scss
+++ b/src/app/admin/admin.page.scss
@@ -1,0 +1,2 @@
+/* Add component styles here if needed */
+

--- a/src/app/admin/admin.page.spec.ts
+++ b/src/app/admin/admin.page.spec.ts
@@ -1,0 +1,13 @@
+import { TestBed } from '@angular/core/testing';
+import { AdminPage } from './admin.page';
+
+describe('AdminPage', () => {
+  beforeEach(() => TestBed.configureTestingModule({ imports: [AdminPage] }));
+
+  it('should create', () => {
+    const fixture = TestBed.createComponent(AdminPage);
+    const app = fixture.componentInstance;
+    expect(app).toBeTruthy();
+  });
+});
+

--- a/src/app/admin/admin.page.ts
+++ b/src/app/admin/admin.page.ts
@@ -1,0 +1,62 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import {
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonContent,
+  IonItem,
+  IonLabel,
+  IonInput,
+  IonButton,
+} from '@ionic/angular/standalone';
+import { MentorApiService } from '../services/mentor-api.service';
+import { ToastController } from '@ionic/angular';
+
+@Component({
+  selector: 'app-admin',
+  standalone: true,
+  templateUrl: './admin.page.html',
+  styleUrls: ['./admin.page.scss'],
+  imports: [
+    CommonModule,
+    FormsModule,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
+    IonContent,
+    IonItem,
+    IonLabel,
+    IonInput,
+    IonButton,
+  ],
+})
+export class AdminPage {
+  mentorId = '';
+  childId = '';
+
+  constructor(
+    private mentorApi: MentorApiService,
+    private toastCtrl: ToastController
+  ) {}
+
+  assign() {
+    if (!this.mentorId || !this.childId) {
+      return;
+    }
+    this.mentorApi
+      .assignMentor({ mentorId: this.mentorId, childId: this.childId })
+      .subscribe(async () => {
+        const toast = await this.toastCtrl.create({
+          message: 'Mentor assigned',
+          duration: 1500,
+          position: 'bottom',
+        });
+        await toast.present();
+        this.mentorId = '';
+        this.childId = '';
+      });
+  }
+}
+

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -55,6 +55,12 @@ export const routes: Routes = [
         data: { title: 'Mentor Board' },
       },
       {
+        path: 'admin',
+        loadComponent: () =>
+          import('./admin/admin.page').then((m) => m.AdminPage),
+        data: { title: 'Assign Mentor' },
+      },
+      {
         path: 'academic-progress',
         loadComponent: () =>
           import('./academic-progress/academic-progress.page').then(

--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -47,6 +47,13 @@
         </ion-col>
       </ion-row>
 
+      <!-- Admin Buttons -->
+      <ion-row *ngIf="role === 'admin'">
+        <ion-col size="6">
+          <ion-button class="tile-button" routerLink="/tabs/admin" expand="block">Assign Mentor</ion-button>
+        </ion-col>
+      </ion-row>
+
       <!-- Child Buttons -->
       <ng-container *ngIf="role === 'child'">
         <ion-row>

--- a/src/app/login/login.page.html
+++ b/src/app/login/login.page.html
@@ -22,6 +22,7 @@
           <ion-select-option value="parent">Parent</ion-select-option>
           <ion-select-option value="child">Child</ion-select-option>
           <ion-select-option value="mentor">Mentor</ion-select-option>
+          <ion-select-option value="admin">Admin</ion-select-option>
         </ion-select>
       </ion-item>
     </ion-list>

--- a/src/app/tabs/tabs.page.html
+++ b/src/app/tabs/tabs.page.html
@@ -25,10 +25,18 @@
     <ion-tab-button
       tab="reward-center"
       href="/tabs/reward-center"
-      *ngIf="role !== 'mentor'"
+      *ngIf="role !== 'mentor' && role !== 'admin'"
     >
       <ion-icon name="gift-outline"></ion-icon>
       <ion-label>Rewards</ion-label>
+    </ion-tab-button>
+    <ion-tab-button
+      tab="admin"
+      href="/tabs/admin"
+      *ngIf="role === 'admin'"
+    >
+      <ion-icon name="settings-outline"></ion-icon>
+      <ion-label>Admin</ion-label>
     </ion-tab-button>
     <ion-button fill="clear" (click)="logout()">
       <ion-icon name="log-out-outline"></ion-icon>


### PR DESCRIPTION
## Summary
- allow choosing admin role at login
- provide admin UI and navigation for mentor assignment

## Testing
- `npm run lint`
- `npm test -- --watch=false` *(fails: No binary for Chrome browser; attempted to install dependencies but received 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68926f8bbf14832796df93962e85d36b