### PR TITLE
fix mentor record api path

### DIFF
--- a/src/app/services/mentor-record-api.service.ts
+++ b/src/app/services/mentor-record-api.service.ts
@@ -9,7 +9,7 @@ import { MentorRecord } from '../models/mentor-record';
 @Injectable({ providedIn: 'root' })
 export class MentorRecordApiService {
   private apiEnabled = !!environment.apiUrl;
-  private readonly baseUrl = `${environment.apiUrl}/api/mentors`;
+  private readonly baseUrl = `${environment.apiUrl}/api/mentor-records`;
 
   constructor(private http: HttpClient, private fb: FirebaseService) {}
 
@@ -18,7 +18,7 @@ export class MentorRecordApiService {
       return from(this.fb.getMentorRecords(childId));
     }
     return this.http
-      .get<MentorRecord[]>(`${this.baseUrl}/${childId}/records`)
+      .get<MentorRecord[]>(`${this.baseUrl}/${childId}`)
       .pipe(catchError(() => from(this.fb.getMentorRecords(childId))));
   }
 
@@ -27,7 +27,7 @@ export class MentorRecordApiService {
       return from(this.fb.saveMentorRecord(record));
     }
     return this.http
-      .post(`${this.baseUrl}/records`, record)
+      .post(this.baseUrl, record)
       .pipe(catchError(() => from(this.fb.saveMentorRecord(record))));
   }
 }


### PR DESCRIPTION
## Summary
- fix mentor record API path to `/api/mentor-records`

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892a354567483278082ed1149f95ddf