### PR TITLE
fix: correct mentor record API paths

### DIFF
--- a/src/app/services/mentor-record-api.service.ts
+++ b/src/app/services/mentor-record-api.service.ts
@@ -9,7 +9,8 @@ import { MentorRecord } from '../models/mentor-record';
 @Injectable({ providedIn: 'root' })
 export class MentorRecordApiService {
   private apiEnabled = !!environment.apiUrl;
-  private readonly baseUrl = `${environment.apiUrl}/api/mentor-records`;
+  // Mentor record endpoints are nested under the mentors route on the server
+  private readonly baseUrl = `${environment.apiUrl}/api/mentors`;
 
   constructor(private http: HttpClient, private fb: FirebaseService) {}
 
@@ -18,7 +19,7 @@ export class MentorRecordApiService {
       return from(this.fb.getMentorRecords(childId));
     }
     return this.http
-      .get<MentorRecord[]>(`${this.baseUrl}/${childId}`)
+      .get<MentorRecord[]>(`${this.baseUrl}/${childId}/records`)
       .pipe(catchError(() => from(this.fb.getMentorRecords(childId))));
   }
 
@@ -27,7 +28,7 @@ export class MentorRecordApiService {
       return from(this.fb.saveMentorRecord(record));
     }
     return this.http
-      .post(this.baseUrl, record)
+      .post(`${this.baseUrl}/records`, record)
       .pipe(catchError(() => from(this.fb.saveMentorRecord(record))));
   }
 }


### PR DESCRIPTION
## Summary
- align mentor record service endpoints with backend mentor routes

## Testing
- `npm run lint`
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6892cf8e3a288327ba2e685893e58e4e