### PR TITLE
Allow children to create mentor-child links

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -19,6 +19,17 @@ service cloud.firestore {
       allow write: if request.auth != null && request.auth.uid == request.resource.data.parentId;
     }
 
+    // Links between mentors and children
+    match /mentorChildLinks/{linkId} {
+      // Allow either participant to read the relationship
+      allow read: if request.auth != null &&
+        (request.auth.uid == resource.data.childId || request.auth.uid == resource.data.mentorId);
+      // Children (or admins) may create a link for themselves
+      allow create: if request.auth != null &&
+        (request.auth.uid == request.resource.data.childId || isAdmin());
+      allow update, delete: if false;
+    }
+
     match /dailyCheckins/{docId} {
       allow read: if isParent(resource) || isChild(resource);
       allow create: if isChild(request.resource);


### PR DESCRIPTION
## Summary
- add security rules for `mentorChildLinks` so children (or admins) can create links and participants can read them

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6892d59e31908327a9ee61ff1b7c45f9