### PR TITLE
feat: support child details and mentor management

### DIFF
--- a/docs/firebase-setup.md
+++ b/docs/firebase-setup.md
@@ -5,6 +5,9 @@ This document describes the Firestore collections and provides basic security ru
 ## Collections
 
 - **parentChildLinks** – links a `parentId` to a `childId`.
+- **children** – child profiles storing `name`, `age`, and `parentId`. Parents must supply both the child's name and age when creating an account.
+- **mentors** – mentor profiles with `name`, `email`, and `phone`.
+- **mentorAssignments** – associates a `mentorId` with a `childId`.
 - **dailyCheckins** – stored check‑in data from the child. Each document should include `childId`, `parentId` and a `timestamp` field.
 - **mentalStatus** – mental health form results. Store `childId`, `parentId` and `timestamp`.
 - **bibleQuizzes** – quiz attempts. Store `childId`, `parentId`, `score` and `timestamp`.

--- a/docs/mentor-api.md
+++ b/docs/mentor-api.md
@@ -1,0 +1,37 @@
+# Mentor API
+
+The backend provides endpoints for creating mentors and linking them to children.
+
+## Create Mentor
+
+`POST /api/mentors/create`
+
+Body:
+```json
+{ "name": "Mentor Name", "email": "mentor@example.com", "phone": "555-1234" }
+```
+
+Response:
+```json
+{ "id": "mentorId", "name": "Mentor Name", "email": "mentor@example.com", "phone": "555-1234" }
+```
+
+Only administrators may access this endpoint.
+
+## Assign Mentor to Child
+
+`POST /api/mentors/assign`
+
+Body:
+```json
+{ "mentorId": "mentorUid", "childId": "childUid" }
+```
+
+## Get Mentor's Children
+
+`GET /api/mentors/:mentorId/children`
+
+Returns:
+```json
+{ "children": ["childUid1", "childUid2"] }
+```

--- a/docs/roles.md
+++ b/docs/roles.md
@@ -16,7 +16,7 @@ The application defines two roles:
    - Include a `role` field with the value `"parent"` or `"child"`.
    - Parents may also store an array `linkedChildIds` containing the UIDs of all child accounts they manage.
 2. **Child Profile Document**
-   - For each child account, create a `/children/{childId}` document storing the child profile and `parentId` reference.
+   - For each child account, create a `/children/{childId}` document storing the child profile (name and age) and `parentId` reference.
    - This allows security rules to verify ownership and enables parents to view their child's records.
 
 ## Example
@@ -36,8 +36,7 @@ await setDoc(doc(db, 'users', childUid), {
 await setDoc(doc(db, 'children', childUid), {
   parentId: parentUid,
   name: childName,
-  dob: childDob,
-  grade: childGrade,
+  age: childAge,
 });
 ```
 

--- a/src/app/admin/admin.page.html
+++ b/src/app/admin/admin.page.html
@@ -1,18 +1,36 @@
 <ion-header>
   <ion-toolbar>
-    <ion-title>Assign Mentor</ion-title>
+    <ion-title>Admin Tools</ion-title>
   </ion-toolbar>
 </ion-header>
 
 <ion-content class="ion-padding">
-  <ion-item>
-    <ion-label position="stacked">Mentor ID</ion-label>
-    <ion-input [(ngModel)]="mentorId"></ion-input>
-  </ion-item>
-  <ion-item>
-    <ion-label position="stacked">Child ID</ion-label>
-    <ion-input [(ngModel)]="childId"></ion-input>
-  </ion-item>
-  <ion-button expand="block" (click)="assign()">Assign</ion-button>
+  <ion-list>
+    <ion-item>
+      <ion-label position="stacked">Mentor Name</ion-label>
+      <ion-input [(ngModel)]="mentor.name"></ion-input>
+    </ion-item>
+    <ion-item>
+      <ion-label position="stacked">Mentor Email</ion-label>
+      <ion-input type="email" [(ngModel)]="mentor.email"></ion-input>
+    </ion-item>
+    <ion-item>
+      <ion-label position="stacked">Mentor Phone</ion-label>
+      <ion-input [(ngModel)]="mentor.phone"></ion-input>
+    </ion-item>
+    <ion-button expand="block" (click)="createMentor()">Create Mentor</ion-button>
+  </ion-list>
+
+  <ion-list>
+    <ion-item>
+      <ion-label position="stacked">Mentor ID</ion-label>
+      <ion-input [(ngModel)]="mentorId"></ion-input>
+    </ion-item>
+    <ion-item>
+      <ion-label position="stacked">Child ID</ion-label>
+      <ion-input [(ngModel)]="childId"></ion-input>
+    </ion-item>
+    <ion-button expand="block" (click)="assign()">Assign</ion-button>
+  </ion-list>
 </ion-content>
 

--- a/src/app/admin/admin.page.ts
+++ b/src/app/admin/admin.page.ts
@@ -10,6 +10,7 @@ import {
   IonLabel,
   IonInput,
   IonButton,
+  IonList,
 } from '@ionic/angular/standalone';
 import { MentorApiService } from '../services/mentor-api.service';
 import { ToastController } from '@ionic/angular';
@@ -30,16 +31,36 @@ import { ToastController } from '@ionic/angular';
     IonLabel,
     IonInput,
     IonButton,
+    IonList,
   ],
 })
 export class AdminPage {
   mentorId = '';
   childId = '';
+  mentor = { name: '', email: '', phone: '' };
 
   constructor(
     private mentorApi: MentorApiService,
     private toastCtrl: ToastController
   ) {}
+
+  createMentor() {
+    const { name, email, phone } = this.mentor;
+    if (!name || !email || !phone) {
+      return;
+    }
+    this.mentorApi
+      .createMentor({ name, email, phone })
+      .subscribe(async () => {
+        const toast = await this.toastCtrl.create({
+          message: 'Mentor created',
+          duration: 1500,
+          position: 'bottom',
+        });
+        await toast.present();
+        this.mentor = { name: '', email: '', phone: '' };
+      });
+  }
 
   assign() {
     if (!this.mentorId || !this.childId) {

--- a/src/app/child-account/child-account.page.html
+++ b/src/app/child-account/child-account.page.html
@@ -8,6 +8,10 @@
   <ion-content class="ion-padding">
   <ion-list>
     <ion-item>
+      <ion-label position="stacked">Child Name</ion-label>
+      <ion-input [(ngModel)]="form.name"></ion-input>
+    </ion-item>
+    <ion-item>
       <ion-label position="stacked">Child Email</ion-label>
       <ion-input type="email" [(ngModel)]="form.email"></ion-input>
     </ion-item>

--- a/src/app/child-account/child-account.page.ts
+++ b/src/app/child-account/child-account.page.ts
@@ -36,7 +36,7 @@ import { ToastController } from '@ionic/angular';
   styleUrls: ['./child-account.page.scss'],
 })
 export class ChildAccountPage {
-  form = { email: '', password: '', age: null as number | null };
+  form = { name: '', email: '', password: '', age: null as number | null };
 
   constructor(
     private fb: FirebaseService,
@@ -50,8 +50,8 @@ export class ChildAccountPage {
       return;
     }
 
-    const { email, password, age } = this.form;
-    if (!email || !password || age === null) {
+    const { name, email, password, age } = this.form;
+    if (!name || !email || !password || age === null) {
       const toast = await this.toastCtrl.create({
         message: 'All fields are required',
         duration: 1500,
@@ -62,7 +62,7 @@ export class ChildAccountPage {
     }
 
     try {
-      await this.fb.createChildAccount(email, password, user.uid, age);
+      await this.fb.createChildAccount(email, password, user.uid, name, age);
       const toast = await this.toastCtrl.create({
         message: 'Child account created',
         duration: 1500,

--- a/src/app/models/mentor-profile.ts
+++ b/src/app/models/mentor-profile.ts
@@ -1,0 +1,6 @@
+export interface MentorProfile {
+  id?: string;
+  name: string;
+  email: string;
+  phone: string;
+}

--- a/src/app/services/firebase.service.ts
+++ b/src/app/services/firebase.service.ts
@@ -37,6 +37,7 @@ import { ParentChildLink } from '../models/parent-child-link';
 import { MentorChildLink } from '../models/mentor-child-link';
 import { MentorRecord } from '../models/mentor-record';
 import { AppNotification } from '../models/notification';
+import { MentorProfile } from '../models/mentor-profile';
 @Injectable({ providedIn: 'root' })
 export class FirebaseService {
   private app = initializeApp(environment.firebase);
@@ -67,6 +68,7 @@ export class FirebaseService {
     email: string,
     password: string,
     parentId: string,
+    name: string,
     age: number
   ) {
     const cred = await createUserWithEmailAndPassword(this.auth, email, password);
@@ -74,7 +76,7 @@ export class FirebaseService {
       parentId,
       childId: cred.user.uid,
     });
-    await setDoc(doc(this.db, 'childProfiles', cred.user.uid), { age });
+    await setDoc(doc(this.db, 'childProfiles', cred.user.uid), { name, age });
     return cred;
   }
 
@@ -275,6 +277,15 @@ export class FirebaseService {
     return snap.docs.map(
       (d) => ({ id: d.id, ...(d.data() as Omit<LeaderboardEntry, 'id'>) })
     );
+  }
+
+  async createMentor(name: string, email: string, phone: string): Promise<MentorProfile> {
+    const docRef = await addDoc(collection(this.db, 'mentors'), {
+      name,
+      email,
+      phone,
+    });
+    return { id: docRef.id, name, email, phone };
   }
 
   assignMentor(mentorId: string, childId: string){


### PR DESCRIPTION
## Summary
- allow parents to specify child name and age when adding accounts
- permit admins to create mentor profiles with name, email, and phone
- document child age requirement and mentor API endpoints

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_6892e3f02c888327b10899aa6ad94642