### PR TITLE
Allow admins to create mentor profiles

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -30,6 +30,15 @@ service cloud.firestore {
       allow update, delete: if false;
     }
 
+    // Mentor profiles
+    match /mentors/{mentorId} {
+      // Any authenticated user can read mentor profiles
+      allow read: if request.auth != null;
+      // Only admins may create new mentor profiles
+      allow create: if isAdmin();
+      allow update, delete: if false;
+    }
+
     match /dailyCheckins/{docId} {
       allow read: if isParent(resource) || isChild(resource);
       allow create: if isChild(request.resource);


### PR DESCRIPTION
## Summary
- add Firestore rules for mentors collection
- allow authenticated reads; only admins can create mentor profiles

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform. Please, set "CHROME_BIN" env variable.)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892e83818c483279128b12ba6bed534