### PR TITLE
feat: add mentor and child selection in admin

### DIFF
--- a/src/app/admin/admin.page.html
+++ b/src/app/admin/admin.page.html
@@ -23,12 +23,20 @@
 
   <ion-list>
     <ion-item>
-      <ion-label position="stacked">Mentor ID</ion-label>
-      <ion-input [(ngModel)]="mentorId"></ion-input>
+      <ion-label position="stacked">Mentor</ion-label>
+      <ion-select [(ngModel)]="selectedMentorId">
+        <ion-select-option *ngFor="let m of mentors" [value]="m.id">
+          {{ m.name }}
+        </ion-select-option>
+      </ion-select>
     </ion-item>
     <ion-item>
-      <ion-label position="stacked">Child ID</ion-label>
-      <ion-input [(ngModel)]="childId"></ion-input>
+      <ion-label position="stacked">Child</ion-label>
+      <ion-select [(ngModel)]="selectedChildId">
+        <ion-select-option *ngFor="let c of children" [value]="c.id">
+          {{ c.name }}
+        </ion-select-option>
+      </ion-select>
     </ion-item>
     <ion-button expand="block" (click)="assign()">Assign</ion-button>
   </ion-list>

--- a/src/app/admin/admin.page.spec.ts
+++ b/src/app/admin/admin.page.spec.ts
@@ -1,8 +1,29 @@
 import { TestBed } from '@angular/core/testing';
 import { AdminPage } from './admin.page';
+import { of } from 'rxjs';
+import { MentorApiService } from '../services/mentor-api.service';
+import { ToastController } from '@ionic/angular';
 
 describe('AdminPage', () => {
-  beforeEach(() => TestBed.configureTestingModule({ imports: [AdminPage] }));
+  const mentorApiStub = {
+    getMentors: () => of([]),
+    getChildProfiles: () => of([]),
+    createMentor: () => of({}),
+    assignMentor: () => of({}),
+  };
+  const toastCtrlStub = {
+    create: () => Promise.resolve({ present: () => Promise.resolve() }),
+  };
+
+  beforeEach(() =>
+    TestBed.configureTestingModule({
+      imports: [AdminPage],
+      providers: [
+        { provide: MentorApiService, useValue: mentorApiStub },
+        { provide: ToastController, useValue: toastCtrlStub },
+      ],
+    })
+  );
 
   it('should create', () => {
     const fixture = TestBed.createComponent(AdminPage);

--- a/src/app/admin/admin.page.ts
+++ b/src/app/admin/admin.page.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import {
@@ -11,9 +11,13 @@ import {
   IonInput,
   IonButton,
   IonList,
+  IonSelect,
+  IonSelectOption,
 } from '@ionic/angular/standalone';
 import { MentorApiService } from '../services/mentor-api.service';
 import { ToastController } from '@ionic/angular';
+import { MentorProfile } from '../models/mentor-profile';
+import { ChildProfile } from '../models/child-profile';
 
 @Component({
   selector: 'app-admin',
@@ -32,17 +36,28 @@ import { ToastController } from '@ionic/angular';
     IonInput,
     IonButton,
     IonList,
+    IonSelect,
+    IonSelectOption,
   ],
 })
-export class AdminPage {
-  mentorId = '';
-  childId = '';
+export class AdminPage implements OnInit {
   mentor = { name: '', email: '', phone: '' };
+  mentors: MentorProfile[] = [];
+  children: ChildProfile[] = [];
+  selectedMentorId = '';
+  selectedChildId = '';
 
   constructor(
     private mentorApi: MentorApiService,
     private toastCtrl: ToastController
   ) {}
+
+  ngOnInit() {
+    this.mentorApi.getMentors().subscribe((m) => (this.mentors = m));
+    this.mentorApi
+      .getChildProfiles()
+      .subscribe((c) => (this.children = c));
+  }
 
   createMentor() {
     const { name, email, phone } = this.mentor;
@@ -63,11 +78,14 @@ export class AdminPage {
   }
 
   assign() {
-    if (!this.mentorId || !this.childId) {
+    if (!this.selectedMentorId || !this.selectedChildId) {
       return;
     }
     this.mentorApi
-      .assignMentor({ mentorId: this.mentorId, childId: this.childId })
+      .assignMentor({
+        mentorId: this.selectedMentorId,
+        childId: this.selectedChildId,
+      })
       .subscribe(async () => {
         const toast = await this.toastCtrl.create({
           message: 'Mentor assigned',
@@ -75,8 +93,8 @@ export class AdminPage {
           position: 'bottom',
         });
         await toast.present();
-        this.mentorId = '';
-        this.childId = '';
+        this.selectedMentorId = '';
+        this.selectedChildId = '';
       });
   }
 }

--- a/src/app/models/child-profile.ts
+++ b/src/app/models/child-profile.ts
@@ -1,0 +1,5 @@
+export interface ChildProfile {
+  id?: string;
+  name: string;
+  age: number;
+}

--- a/src/app/services/firebase.service.ts
+++ b/src/app/services/firebase.service.ts
@@ -38,6 +38,7 @@ import { MentorChildLink } from '../models/mentor-child-link';
 import { MentorRecord } from '../models/mentor-record';
 import { AppNotification } from '../models/notification';
 import { MentorProfile } from '../models/mentor-profile';
+import { ChildProfile } from '../models/child-profile';
 @Injectable({ providedIn: 'root' })
 export class FirebaseService {
   private app = initializeApp(environment.firebase);
@@ -286,6 +287,22 @@ export class FirebaseService {
       phone,
     });
     return { id: docRef.id, name, email, phone };
+  }
+
+  async getMentors(): Promise<MentorProfile[]> {
+    const snap = await getDocs(collection(this.db, 'mentors'));
+    return snap.docs.map((d) => ({
+      id: d.id,
+      ...(d.data() as Omit<MentorProfile, 'id'>),
+    }));
+  }
+
+  async getAllChildren(): Promise<ChildProfile[]> {
+    const snap = await getDocs(collection(this.db, 'childProfiles'));
+    return snap.docs.map((d) => ({
+      id: d.id,
+      ...(d.data() as Omit<ChildProfile, 'id'>),
+    }));
   }
 
   assignMentor(mentorId: string, childId: string){


### PR DESCRIPTION
## Summary
- Replace manual ID entry with mentor and child dropdowns on Admin page
- Load mentor and child lists via new API methods and Firebase fallbacks
- Introduce `ChildProfile` model

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68935c0699bc8327a14e3a3143d04170