### PR TITLE
feat: add error modal and interceptor

### DIFF
--- a/src/app/child-account/child-account.page.ts
+++ b/src/app/child-account/child-account.page.ts
@@ -15,6 +15,8 @@ import {
 import { FirebaseService } from '../services/firebase.service';
 import { Router } from '@angular/router';
 import { ToastController } from '@ionic/angular';
+import { ErrorService } from '../services/error.service';
+import { FirebaseError } from 'firebase/app';
 
 @Component({
   selector: 'app-child-account',
@@ -41,7 +43,8 @@ export class ChildAccountPage {
   constructor(
     private fb: FirebaseService,
     private router: Router,
-    private toastCtrl: ToastController
+    private toastCtrl: ToastController,
+    private errorSvc: ErrorService
   ) {}
 
   async create() {
@@ -71,15 +74,12 @@ export class ChildAccountPage {
       await toast.present();
       this.router.navigateByUrl('/tabs/home');
     } catch (err) {
-      const toast = await this.toastCtrl.create({
-        message:
-          err instanceof Error
-            ? err.message
-            : 'Unable to create child account',
-        duration: 2000,
-        position: 'bottom',
-      });
-      await toast.present();
+      if (err instanceof FirebaseError && err.code === 'auth/email-already-in-use') {
+        await this.errorSvc.presentError('The Child you are trying to add already exist');
+      } else {
+        const msg = err instanceof Error ? err.message : 'Unable to create child account';
+        await this.errorSvc.presentError(msg);
+      }
     }
   }
 }

--- a/src/app/services/error.interceptor.ts
+++ b/src/app/services/error.interceptor.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpErrorResponse,
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest,
+} from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { ErrorService } from './error.service';
+
+@Injectable()
+export class ErrorInterceptor implements HttpInterceptor {
+  constructor(private errorService: ErrorService) {}
+
+  intercept(
+    req: HttpRequest<any>,
+    next: HttpHandler
+  ): Observable<HttpEvent<any>> {
+    return next.handle(req).pipe(
+      catchError((err: HttpErrorResponse) => {
+        let message = 'An unexpected error occurred';
+        if (err.status === 400) {
+          message = 'Bad request';
+        } else if (err.status === 404) {
+          message = 'Resource not found';
+        } else if (err.status === 0) {
+          message = 'Network error';
+        }
+        this.errorService.presentError(message);
+        return throwError(() => err);
+      })
+    );
+  }
+}

--- a/src/app/services/error.service.ts
+++ b/src/app/services/error.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { AlertController } from '@ionic/angular';
+
+@Injectable({ providedIn: 'root' })
+export class ErrorService {
+  constructor(private alertCtrl: AlertController) {}
+
+  async presentError(message: string, header = 'Error') {
+    const alert = await this.alertCtrl.create({
+      header,
+      message,
+      buttons: ['OK'],
+    });
+    await alert.present();
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,7 @@ import {
   menu,
 } from 'ionicons/icons';
 import { AuthInterceptor } from './app/services/auth.interceptor';
+import { ErrorInterceptor } from './app/services/error.interceptor';
 
 import { routes } from './app/app.routes';
 import { AppComponent } from './app/app.component';
@@ -62,5 +63,6 @@ bootstrapApplication(AppComponent, {
     provideRouter(routes, withPreloading(PreloadAllModules)),
     importProvidersFrom(HttpClientModule),
     { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true },
+    { provide: HTTP_INTERCEPTORS, useClass: ErrorInterceptor, multi: true },
   ],
 });


### PR DESCRIPTION
## Summary
- show modal alerts for HTTP errors and duplicate child emails
- global ErrorInterceptor surfaces 400/404/network issues
- register interceptor during app bootstrap

## Testing
- `npm run lint`
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68939ae2708083279c27f8bdfd284b98