### PR TITLE
fix: correct mentor creation endpoint

### DIFF
--- a/docs/mentor-api.md
+++ b/docs/mentor-api.md
@@ -4,7 +4,7 @@ The backend provides endpoints for creating mentors and linking them to children
 
 ## Create Mentor
 
-`POST /api/mentors/create`
+`POST /api/mentors`
 
 Body:
 ```json

--- a/src/app/services/mentor-api.service.ts
+++ b/src/app/services/mentor-api.service.ts
@@ -27,7 +27,7 @@ export class MentorApiService {
 
     return token$.pipe(
       switchMap((token) =>
-        this.http.post<MentorProfile>(`${this.baseUrl}/create`, data, {
+        this.http.post<MentorProfile>(this.baseUrl, data, {
           headers: token ? { Authorization: `Bearer ${token}` } : {},
         })
       ),


### PR DESCRIPTION
## Summary
- call mentor creation API at `/api/mentors`
- update Mentor API docs for new endpoint

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893d99b47308327b27c7a5750f84ae1