### PR TITLE
Allow admin to read child profiles

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -39,6 +39,17 @@ service cloud.firestore {
       allow update, delete: if false;
     }
 
+    // Child profiles
+    match /childProfiles/{childId} {
+      // Children may access their own profile; admins can access all
+      allow read: if request.auth != null &&
+        (request.auth.uid == childId || isAdmin());
+      // Children can create or update their profile document, admins can manage any
+      allow create, update: if request.auth != null &&
+        (request.auth.uid == childId || isAdmin());
+      allow delete: if false;
+    }
+
     match /dailyCheckins/{docId} {
       allow read: if isParent(resource) || isChild(resource);
       allow create: if isChild(request.resource);


### PR DESCRIPTION
## Summary
- permit admins and children to access child profile documents in Firestore

## Testing
- `npm run lint`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6893e14d262c8327a64d1d79160a8e8a