### PR TITLE
Fix mentor API services to match backend endpoints

### DIFF
--- a/src/app/services/mentor-api.service.ts
+++ b/src/app/services/mentor-api.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, from, switchMap } from 'rxjs';
+import { Observable, from, switchMap, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { environment } from '../../environments/environment';
 import { FirebaseService } from './firebase.service';
@@ -54,8 +54,11 @@ export class MentorApiService {
         })
       ),
       catchError((err) => {
-        console.error('Failed to fetch mentors via API, falling back', err);
-        return from(this.fb.getMentors());
+        if (err.status === 0) {
+          console.error('Failed to fetch mentors via API, falling back', err);
+          return from(this.fb.getMentors());
+        }
+        return throwError(() => err);
       })
     );
   }
@@ -76,8 +79,11 @@ export class MentorApiService {
         })
       ),
       catchError((err) => {
-        console.error('Failed to fetch children via API, falling back', err);
-        return from(this.fb.getAllChildren());
+        if (err.status === 0) {
+          console.error('Failed to fetch children via API, falling back', err);
+          return from(this.fb.getAllChildren());
+        }
+        return throwError(() => err);
       })
     );
   }

--- a/src/app/services/mentor-record-api.service.ts
+++ b/src/app/services/mentor-record-api.service.ts
@@ -9,18 +9,18 @@ import { MentorRecord } from '../models/mentor-record';
 @Injectable({ providedIn: 'root' })
 export class MentorRecordApiService {
   private apiEnabled = !!environment.apiUrl;
-  // Mentor record endpoints have a dedicated route on the server
-  private readonly baseUrl = `${environment.apiUrl}/api/mentor-records`;
+  // Mentor record endpoints live under the mentors route on the backend
+  private readonly baseUrl = `${environment.apiUrl}/api/mentors`;
 
   constructor(private http: HttpClient, private fb: FirebaseService) {}
 
-  getRecords(childId: string): Observable<MentorRecord[]> {
+  getRecords(uid: string): Observable<MentorRecord[]> {
     if (!this.apiEnabled) {
-      return from(this.fb.getMentorRecords(childId));
+      return from(this.fb.getMentorRecords(uid));
     }
     return this.http
-      .get<MentorRecord[]>(`${this.baseUrl}/${childId}`)
-      .pipe(catchError(() => from(this.fb.getMentorRecords(childId))));
+      .get<MentorRecord[]>(`${this.baseUrl}/${uid}/records`)
+      .pipe(catchError(() => from(this.fb.getMentorRecords(uid))));
   }
 
   createRecord(record: MentorRecord): Observable<unknown> {
@@ -28,7 +28,7 @@ export class MentorRecordApiService {
       return from(this.fb.saveMentorRecord(record));
     }
     return this.http
-      .post(this.baseUrl, record)
+      .post(`${this.baseUrl}/records`, record)
       .pipe(catchError(() => from(this.fb.saveMentorRecord(record))));
   }
 }


### PR DESCRIPTION
## Summary
- align mentor record API calls with `/api/mentors` backend routes
- avoid Firebase fallback for mentor APIs when backend returns an HTTP error

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68942a3f78208327be4822bf44759b74