### PR TITLE
fix: handle mentor children errors

### DIFF
--- a/src/app/services/mentor-api.service.ts
+++ b/src/app/services/mentor-api.service.ts
@@ -131,10 +131,16 @@ export class MentorApiService {
         })
       ),
       catchError((err) => {
-        console.error('Failed to fetch mentor children via API, falling back', err);
-        return from(this.fb.getChildForMentor(mentorId)).pipe(
-          map((children) => ({ children }))
-        );
+        if (err.status === 0) {
+          console.error(
+            'Failed to fetch mentor children via API, falling back',
+            err
+          );
+          return from(this.fb.getChildForMentor(mentorId)).pipe(
+            map((children) => ({ children }))
+          );
+        }
+        return throwError(() => err);
       })
     );
   }


### PR DESCRIPTION
## Summary
- handle mentor-children fetch errors like other API calls

## Testing
- `npm test` *(fails: ng not found)*
- `npm install @angular/cli` *(fails: 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689435aa3ea48327b3d9e2ac1dadd0af