### PR TITLE
fix: ensure auth token added to requests

### DIFF
--- a/src/app/services/auth.interceptor.ts
+++ b/src/app/services/auth.interceptor.ts
@@ -14,15 +14,23 @@ export class AuthInterceptor implements HttpInterceptor {
   constructor(private fb: FirebaseService) {}
 
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    const user = this.fb.auth.currentUser;
-    if (!user) {
-      return next.handle(req);
-    }
-    return from(user.getIdToken()).pipe(
-      switchMap((token) => {
-        const authReq = req.clone({
-          setHeaders: { Authorization: `Bearer ${token}` },
+    // Resolve the current user's ID token. If the auth state has not yet been
+    // loaded, wait for it so that authenticated requests still include the
+    // appropriate Authorization header.
+    const tokenPromise = this.fb.auth.currentUser
+      ? this.fb.auth.currentUser.getIdToken()
+      : new Promise<string | null>((resolve) => {
+          const unsubscribe = this.fb.auth.onAuthStateChanged(async (user) => {
+            unsubscribe();
+            resolve(user ? await user.getIdToken() : null);
+          });
         });
+
+    return from(tokenPromise).pipe(
+      switchMap((token) => {
+        const authReq = token
+          ? req.clone({ setHeaders: { Authorization: `Bearer ${token}` } })
+          : req;
         return next.handle(authReq);
       })
     );


### PR DESCRIPTION
## Summary
- wait for Firebase auth state before attaching ID token
- ensure Authorization header is applied to HTTP requests

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689446b7000883279dda06c56f4cc52b