### PR TITLE
Fix mentor API path for mentor creation

### DIFF
--- a/src/app/admin/admin-parent-child.page.ts
+++ b/src/app/admin/admin-parent-child.page.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { ParentChildService } from '../services/parent-child.service';
 import { FirebaseService } from '../services/firebase.service';
 import { IonButton, IonContent, IonHeader, IonInput, IonItem, IonLabel, IonList, IonTitle, IonToolbar } from '@ionic/angular/standalone';
@@ -24,7 +24,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
     ReactiveFormsModule
    ]
 })
-export class AdminParentChildPage implements OnInit {
+export class AdminParentChildPage {
   parentId = '';
   childId = '';
   linkedChildren: string[] = [];
@@ -34,7 +34,6 @@ export class AdminParentChildPage implements OnInit {
     private fb: FirebaseService
   ) {}
 
-  ngOnInit(): void {}
 
   link() {
     if (!this.parentId || !this.childId) return;

--- a/src/app/services/mentor-api.service.ts
+++ b/src/app/services/mentor-api.service.ts
@@ -10,7 +10,8 @@ import { ChildProfile } from '../models/child-profile';
 
 @Injectable({ providedIn: 'root' })
 export class MentorApiService {
-  private readonly baseUrl = `${environment.apiUrl}/api/mentor`;
+  // Backend mentor endpoints reside under the plural 'mentors' route
+  private readonly baseUrl = `${environment.apiUrl}/api/mentors`;
   private readonly childBaseUrl = `${environment.apiUrl}/api/children`;
 
   constructor(private http: HttpClient, private fb: FirebaseService) {}


### PR DESCRIPTION
## Summary
- use `/api/mentors` base path for mentor endpoints
- remove unused `OnInit` hook from AdminParentChildPage to satisfy lint

## Testing
- `npm run lint`
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68958196b42c8327adef46cb2150416e