### PR TITLE
fix: correct mentor and child API paths

### DIFF
--- a/docs/mentor-api.md
+++ b/docs/mentor-api.md
@@ -4,7 +4,7 @@ The backend provides endpoints for creating mentors and linking them to children
 
 ## Create Mentor
 
-`POST /api/mentors`
+`POST /mentors`
 
 Body:
 ```json
@@ -20,7 +20,7 @@ Only administrators may access this endpoint.
 
 ## Assign Mentor to Child
 
-`POST /api/mentors/assign`
+`POST /mentors/assign`
 
 Body:
 ```json
@@ -29,7 +29,7 @@ Body:
 
 ## Get Mentor's Children
 
-`GET /api/mentors/:mentorId/children`
+`GET /mentors/:mentorId/children`
 
 Returns:
 ```json

--- a/src/app/services/mentor-api.service.ts
+++ b/src/app/services/mentor-api.service.ts
@@ -11,8 +11,9 @@ import { ChildProfile } from '../models/child-profile';
 @Injectable({ providedIn: 'root' })
 export class MentorApiService {
   // Backend mentor endpoints reside under the plural 'mentors' route
-  private readonly baseUrl = `${environment.apiUrl}/api/mentors`;
-  private readonly childBaseUrl = `${environment.apiUrl}/api/children`;
+  // The backend no longer prefixes routes with /api
+  private readonly baseUrl = `${environment.apiUrl}/mentors`;
+  private readonly childBaseUrl = `${environment.apiUrl}/children`;
 
   constructor(private http: HttpClient, private fb: FirebaseService) {}
 

--- a/src/app/services/mentor-record-api.service.ts
+++ b/src/app/services/mentor-record-api.service.ts
@@ -10,7 +10,8 @@ import { MentorRecord } from '../models/mentor-record';
 export class MentorRecordApiService {
   private apiEnabled = !!environment.apiUrl;
   // Mentor record endpoints live under the mentors route on the backend
-  private readonly baseUrl = `${environment.apiUrl}/api/mentors`;
+  // The backend no longer uses the /api prefix
+  private readonly baseUrl = `${environment.apiUrl}/mentors`;
 
   constructor(private http: HttpClient, private fb: FirebaseService) {}
 

--- a/src/app/services/parent-child.service.ts
+++ b/src/app/services/parent-child.service.ts
@@ -5,7 +5,8 @@ import { Observable } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class ParentChildService {
-  private readonly baseUrl = `${environment.apiUrl}/api/parent-child`;
+  // Backend routes no longer include the /api prefix
+  private readonly baseUrl = `${environment.apiUrl}/parent-child`;
 
   constructor(private http: HttpClient) {}
 


### PR DESCRIPTION
## Summary
- remove outdated `/api` prefix from mentor, child, and parent-child service base URLs
- update mentor API documentation to match new endpoints

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68960dcb97208327bf6df9764b4c2233