### PR TITLE
fix: include api prefix for backend routes

### DIFF
--- a/src/app/services/mentor-api.service.ts
+++ b/src/app/services/mentor-api.service.ts
@@ -10,8 +10,8 @@ import { ChildProfile } from '../models/child-profile';
 
 @Injectable({ providedIn: 'root' })
 export class MentorApiService {
-  // Backend mentor endpoints reside under the plural 'mentors' route
-  // The backend no longer prefixes routes with /api
+  // Backend mentor endpoints reside under the plural 'mentors' route.
+  // Ensure the environment.apiUrl includes the `/api` prefix used by the backend.
   private readonly baseUrl = `${environment.apiUrl}/mentors`;
   private readonly childBaseUrl = `${environment.apiUrl}/children`;
 

--- a/src/app/services/mentor-record-api.service.ts
+++ b/src/app/services/mentor-record-api.service.ts
@@ -9,8 +9,8 @@ import { MentorRecord } from '../models/mentor-record';
 @Injectable({ providedIn: 'root' })
 export class MentorRecordApiService {
   private apiEnabled = !!environment.apiUrl;
-  // Mentor record endpoints live under the mentors route on the backend
-  // The backend no longer uses the /api prefix
+  // Mentor record endpoints live under the mentors route on the backend. The
+  // backend prefixes routes with `/api`, so environment.apiUrl should include it.
   private readonly baseUrl = `${environment.apiUrl}/mentors`;
 
   constructor(private http: HttpClient, private fb: FirebaseService) {}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -9,5 +9,6 @@ export const environment = {
     appId: "1:54742577057:web:cfca5e902ab173a77025e0",
     measurementId: "G-91V8B05X5E"
   },
-  apiUrl: 'https://gfharvestbackend-1.onrender.com'
+  // Backend routes are served under the /api prefix
+  apiUrl: 'https://gfharvestbackend-1.onrender.com/api'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -14,10 +14,10 @@ export const environment = {
     appId: "1:54742577057:web:cfca5e902ab173a77025e0",
     measurementId: "G-91V8B05X5E"
   },
-  // Leave apiUrl empty when no backend service is available. Using an empty
-  // string ensures the application falls back to Firebase when the backend
-  // API is not running during local development.
-  apiUrl: ''
+  // Base URL for the backend API. Use the local server during development.
+  // Set to an empty string ('') to fall back to Firebase when the backend is
+  // not running.
+  apiUrl: 'http://localhost:3000/api'
 };
 
 


### PR DESCRIPTION
## Summary
- point frontend environments to `/api` prefix
- clarify mentor API comments regarding `/api` base

## Testing
- `npm run lint`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68961723c02883278422c47ee5a12a04