### PR TITLE
Handle mentor list response from API

### DIFF
--- a/src/app/services/mentor-api.service.ts
+++ b/src/app/services/mentor-api.service.ts
@@ -53,8 +53,14 @@ export class MentorApiService {
 
   getMentors(): Observable<MentorProfile[]> {
     return this.withToken((token) =>
-      this.http.get<MentorProfile[]>(this.baseUrl, {
+      this.http.get<MentorProfile[] | { mentors: MentorProfile[] }>(this.baseUrl, {
         headers: { Authorization: `Bearer ${token}` },
+      })
+    ).pipe(
+      map((res) => (Array.isArray(res) ? res : res.mentors ?? [])),
+      catchError((err) => {
+        console.error('getMentors API error', err);
+        return from(this.fb.getMentors());
       })
     );
   }


### PR DESCRIPTION
## Summary
- Ensure mentor retrieval accepts raw arrays or `{ mentors: [] }` response shapes and falls back to Firebase on errors.

## Testing
- `npm run lint`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless; attempted `apt-get update` but repositories unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6896ec9b18388327963f024a3662f364