### PR TITLE
Fix child profile loading in admin

### DIFF
--- a/src/app/services/mentor-api.service.ts
+++ b/src/app/services/mentor-api.service.ts
@@ -67,8 +67,17 @@ export class MentorApiService {
 
   getChildProfiles(): Observable<ChildProfile[]> {
     return this.withToken((token) =>
-      this.http.get<ChildProfile[]>(this.childBaseUrl, {
-        headers: { Authorization: `Bearer ${token}` },
+      this.http.get<ChildProfile[] | { children: ChildProfile[] }>(
+        this.childBaseUrl,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        }
+      )
+    ).pipe(
+      map((res) => (Array.isArray(res) ? res : res.children ?? [])),
+      catchError((err) => {
+        console.error('getChildProfiles API error', err);
+        return throwError(() => err);
       })
     );
   }


### PR DESCRIPTION
## Summary
- normalize `getChildProfiles` to handle array or `{children: []}` response
- add error logging on child profile requests

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6896ef8a77988327b65d885f349278c6