### PR TITLE
Expose admin management and parent-child pages in portal

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -82,6 +82,14 @@
             <ion-icon slot="start" name="shield-outline"></ion-icon>
             <ion-label>Assign Mentor</ion-label>
           </ion-item>
+          <ion-item routerLink="/tabs/admin-parent-child" *ngIf="role === 'admin'">
+            <ion-icon slot="start" name="people-outline"></ion-icon>
+            <ion-label>Parent Child</ion-label>
+          </ion-item>
+          <ion-item routerLink="/tabs/admin-user-management" *ngIf="role === 'admin'">
+            <ion-icon slot="start" name="person-outline"></ion-icon>
+            <ion-label>User Management</ion-label>
+          </ion-item>
         </ion-menu-toggle>
       </ion-list>
     </ion-content>

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -61,12 +61,20 @@ export const routes: Routes = [
         data: { title: 'Assign Mentor' },
       },
       {
-        path: 'admin-users',
+        path: 'admin-user-management',
         loadComponent: () =>
           import('./admin/admin-user-management.page').then(
             (m) => m.AdminUserManagementPage
           ),
         data: { title: 'User Management' },
+      },
+      {
+        path: 'admin-parent-child',
+        loadComponent: () =>
+          import('./admin/admin-parent-child.page').then(
+            (m) => m.AdminParentChildPage
+          ),
+        data: { title: 'Parent Child' },
       },
       {
         path: 'academic-progress',

--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -52,6 +52,24 @@
         <ion-col size="6">
           <ion-button class="tile-button" routerLink="/tabs/admin" expand="block">Assign Mentor</ion-button>
         </ion-col>
+        <ion-col size="6">
+          <ion-button
+            class="tile-button"
+            routerLink="/tabs/admin-parent-child"
+            expand="block"
+            >Parent Child</ion-button
+          >
+        </ion-col>
+      </ion-row>
+      <ion-row *ngIf="role === 'admin'">
+        <ion-col size="6">
+          <ion-button
+            class="tile-button"
+            routerLink="/tabs/admin-user-management"
+            expand="block"
+            >User Management</ion-button
+          >
+        </ion-col>
       </ion-row>
 
       <!-- Child Buttons -->


### PR DESCRIPTION
## Summary
- add routes for admin-parent-child and admin-user-management pages
- show admin links in side menu
- display tiles for admin management pages on home screen

## Testing
- `npm run lint`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform; apt-get update failed with 403)*

------
https://chatgpt.com/codex/tasks/task_e_689800f7deb88327ab93e7a07be10002