### PR TITLE
fix: display users in admin page

### DIFF
--- a/src/app/admin/admin-user-management.page.html
+++ b/src/app/admin/admin-user-management.page.html
@@ -13,5 +13,8 @@
       </ion-select>
       <ion-button (click)="updateRole(user)">Update</ion-button>
     </ion-item>
+    <ion-item *ngIf="users.length === 0">
+      <ion-label>No users found.</ion-label>
+    </ion-item>
   </ion-list>
 </ion-content>


### PR DESCRIPTION
## Summary
- fix user list retrieval to handle object responses
- show fallback message when no users exist

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68980a5a0b108327abbac73cc66062f3