### PR TITLE
Default to Firebase functions when backend is absent

### DIFF
--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -14,10 +14,10 @@ export const environment = {
     appId: "1:54742577057:web:cfca5e902ab173a77025e0",
     measurementId: "G-91V8B05X5E"
   },
-  // Base URL for the backend API. Use the local server during development.
-  // Set to an empty string ('') to fall back to Firebase when the backend is
-  // not running.
-  apiUrl: 'http://localhost:3000/api'
+  // Base URL for the backend API. Default to an empty string so the app falls
+  // back to Firebase when a local backend isn't running. Change this to your
+  // development server's URL (e.g. 'http://localhost:3000/api') when needed.
+  apiUrl: ''
 };
 
 


### PR DESCRIPTION
## Summary
- Default development API URL to empty so the app falls back to Firebase functions when no local backend is running
- Document how to point to a development server if needed

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68980e1dc1248327b05a57069b82f312