### PR TITLE
Bind role select to user model and log loaded users

### DIFF
--- a/src/app/admin/admin-user-management.page.html
+++ b/src/app/admin/admin-user-management.page.html
@@ -8,8 +8,12 @@
   <ion-list>
     <ion-item *ngFor="let user of users; trackBy: trackByUid">
       <ion-label>{{ user.displayName || user.email }}</ion-label>
-      <ion-select placeholder="Select Role" interface="alert" [interfaceOptions]="{ cssClass: 'role-popover' }"
-        >
+      <ion-select
+        [(ngModel)]="user.role"
+        placeholder="Select Role"
+        interface="alert"
+        [interfaceOptions]="{ cssClass: 'role-popover' }"
+      >
         <ion-select-option *ngFor="let r of roles" [value]="r">
           {{ r }}
         </ion-select-option>

--- a/src/app/admin/admin-user-management.page.ts
+++ b/src/app/admin/admin-user-management.page.ts
@@ -48,11 +48,12 @@ export class AdminUserManagementPage implements OnInit {
 
   loadUsers() {
     this.userApi.getUsers().subscribe({
-      next: (users) => (this.users = users),
+      next: (users) => {
+        this.users = users;
+        console.log('Users', this.users);
+      },
       error: (err) => console.error('Failed to load users', err),
     });
-          console.log("Users",this.users)
-
   }
 
     trackByUid = (_: number, u: User) => u.uid;


### PR DESCRIPTION
## Summary
- Bind admin role dropdown to user.role so updates send selected value
- Log loaded users inside subscription callback

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68991e6eaeac8327b8c2f857345a3465