### PR TITLE
feat: add church and prayer bulletin pages

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -62,6 +62,14 @@
             <ion-icon slot="start" name="trophy-outline"></ion-icon>
             <ion-label>Leaderboard</ion-label>
           </ion-item>
+          <ion-item routerLink="/tabs/churches">
+            <ion-icon slot="start" name="business-outline"></ion-icon>
+            <ion-label>Churches</ion-label>
+          </ion-item>
+          <ion-item routerLink="/tabs/prayer-bulletin">
+            <ion-icon slot="start" name="newspaper-outline"></ion-icon>
+            <ion-label>Prayer Bulletin</ion-label>
+          </ion-item>
           <ion-item routerLink="/tabs/child-account" *ngIf="role === 'parent'">
             <ion-icon slot="start" name="person-add-outline"></ion-icon>
             <ion-label>Add a Child</ion-label>

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -121,6 +121,20 @@ export const routes: Routes = [
         data: { title: 'Mental & Emotional Status' },
       },
       {
+        path: 'churches',
+        loadComponent: () =>
+          import('./churches/churches.page').then((m) => m.ChurchesPage),
+        data: { title: 'Churches' },
+      },
+      {
+        path: 'prayer-bulletin',
+        loadComponent: () =>
+          import('./prayer-bulletin/prayer-bulletin.page').then(
+            (m) => m.PrayerBulletinPage
+          ),
+        data: { title: 'Prayer Bulletin' },
+      },
+      {
         path: '',
         redirectTo: 'home',
         pathMatch: 'full',

--- a/src/app/churches/churches.page.html
+++ b/src/app/churches/churches.page.html
@@ -1,0 +1,24 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Churches</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+  <ion-list>
+    <ion-item *ngFor="let church of churches">
+      <ion-avatar slot="start">
+        <img [src]="church.logoUrl" alt="{{ church.name }} logo" />
+      </ion-avatar>
+      <ion-label>{{ church.name }}</ion-label>
+    </ion-item>
+  </ion-list>
+
+  <ion-item>
+    <ion-input placeholder="Church Name" [(ngModel)]="name"></ion-input>
+  </ion-item>
+  <ion-item>
+    <ion-input placeholder="Logo URL" [(ngModel)]="logoUrl"></ion-input>
+  </ion-item>
+  <ion-button expand="block" (click)="add()">Add Church</ion-button>
+</ion-content>

--- a/src/app/churches/churches.page.scss
+++ b/src/app/churches/churches.page.scss
@@ -1,0 +1,1 @@
+/* Add any styling for churches page here */

--- a/src/app/churches/churches.page.ts
+++ b/src/app/churches/churches.page.ts
@@ -1,0 +1,53 @@
+import { Component } from '@angular/core';
+import { IonHeader, IonToolbar, IonTitle, IonContent, IonList, IonItem, IonLabel, IonInput, IonButton, IonAvatar } from '@ionic/angular/standalone';
+import { FormsModule } from '@angular/forms';
+import { NgFor } from '@angular/common';
+import { ChurchApiService } from '../services/church-api.service';
+import { Church } from '../models/church';
+
+@Component({
+  selector: 'app-churches',
+  templateUrl: './churches.page.html',
+  styleUrls: ['./churches.page.scss'],
+  standalone: true,
+  imports: [
+    IonHeader,
+    IonToolbar,
+    IonTitle,
+    IonContent,
+    IonList,
+    IonItem,
+    IonLabel,
+    IonInput,
+    IonButton,
+    IonAvatar,
+    FormsModule,
+    NgFor,
+  ],
+})
+export class ChurchesPage {
+  churches: Church[] = [];
+  name = '';
+  logoUrl = '';
+
+  constructor(private api: ChurchApiService) {}
+
+  ionViewWillEnter(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.api.list().subscribe((cs) => (this.churches = cs));
+  }
+
+  add(): void {
+    if (!this.name || !this.logoUrl) {
+      return;
+    }
+    this.api.create({ name: this.name, logoUrl: this.logoUrl }).subscribe((c) => {
+      this.churches.push(c);
+      this.name = '';
+      this.logoUrl = '';
+    });
+  }
+}

--- a/src/app/models/church.ts
+++ b/src/app/models/church.ts
@@ -1,0 +1,6 @@
+export interface Church {
+  id?: string;
+  name: string;
+  logoUrl: string;
+  createdAt?: string;
+}

--- a/src/app/models/prayer-request.ts
+++ b/src/app/models/prayer-request.ts
@@ -1,0 +1,7 @@
+export interface PrayerRequest {
+  id?: string;
+  userId: string;
+  text: string;
+  createdAt?: string;
+  prayedAt?: string | null;
+}

--- a/src/app/prayer-bulletin/prayer-bulletin.page.html
+++ b/src/app/prayer-bulletin/prayer-bulletin.page.html
@@ -1,0 +1,26 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Prayer Bulletin</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+  <ion-list>
+    <ion-item *ngFor="let req of requests">
+      <ion-label>
+        <h3>{{ req.text }}</h3>
+        <p>ID: {{ req.userId }}</p>
+        <p *ngIf="req.prayedAt">Prayed at: {{ req.prayedAt | date:'short' }}</p>
+      </ion-label>
+      <ion-button slot="end" *ngIf="!req.prayedAt" (click)="markPrayed(req)">Mark Prayed</ion-button>
+    </ion-item>
+  </ion-list>
+
+  <ion-item>
+    <ion-input placeholder="Your ID" [(ngModel)]="userId"></ion-input>
+  </ion-item>
+  <ion-item>
+    <ion-input placeholder="Prayer request" [(ngModel)]="text"></ion-input>
+  </ion-item>
+  <ion-button expand="block" (click)="add()">Add Request</ion-button>
+</ion-content>

--- a/src/app/prayer-bulletin/prayer-bulletin.page.scss
+++ b/src/app/prayer-bulletin/prayer-bulletin.page.scss
@@ -1,0 +1,1 @@
+/* Styles for prayer bulletin page */

--- a/src/app/prayer-bulletin/prayer-bulletin.page.ts
+++ b/src/app/prayer-bulletin/prayer-bulletin.page.ts
@@ -1,0 +1,62 @@
+import { Component } from '@angular/core';
+import { IonHeader, IonToolbar, IonTitle, IonContent, IonList, IonItem, IonLabel, IonInput, IonButton } from '@ionic/angular/standalone';
+import { FormsModule } from '@angular/forms';
+import { NgFor, DatePipe } from '@angular/common';
+import { PrayerRequestApiService } from '../services/prayer-request-api.service';
+import { PrayerRequest } from '../models/prayer-request';
+
+@Component({
+  selector: 'app-prayer-bulletin',
+  templateUrl: './prayer-bulletin.page.html',
+  styleUrls: ['./prayer-bulletin.page.scss'],
+  standalone: true,
+  imports: [
+    IonHeader,
+    IonToolbar,
+    IonTitle,
+    IonContent,
+    IonList,
+    IonItem,
+    IonLabel,
+    IonInput,
+    IonButton,
+    FormsModule,
+    NgFor,
+    DatePipe,
+  ],
+})
+export class PrayerBulletinPage {
+  requests: PrayerRequest[] = [];
+  userId = '';
+  text = '';
+
+  constructor(private api: PrayerRequestApiService) {}
+
+  ionViewWillEnter(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.api.list().subscribe((rs) => (this.requests = rs));
+  }
+
+  add(): void {
+    if (!this.userId || !this.text) {
+      return;
+    }
+    this.api.create({ userId: this.userId, text: this.text }).subscribe((r) => {
+      this.requests.push(r);
+      this.userId = '';
+      this.text = '';
+    });
+  }
+
+  markPrayed(req: PrayerRequest): void {
+    if (!req.id) {
+      return;
+    }
+    this.api.markPrayed(req.id).subscribe((res) => {
+      req.prayedAt = res.prayedAt;
+    });
+  }
+}

--- a/src/app/services/church-api.service.ts
+++ b/src/app/services/church-api.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { environment } from '../../environments/environment';
+import { Church } from '../models/church';
+
+@Injectable({ providedIn: 'root' })
+export class ChurchApiService {
+  private apiEnabled = !!environment.apiUrl;
+  private readonly baseUrl = `${environment.apiUrl}/churches`;
+  private fallback: Church[] = [];
+
+  constructor(private http: HttpClient) {}
+
+  list(): Observable<Church[]> {
+    if (!this.apiEnabled) {
+      return of(this.fallback);
+    }
+    return this.http.get<Church[]>(this.baseUrl);
+  }
+
+  create(church: { name: string; logoUrl: string }): Observable<Church> {
+    if (!this.apiEnabled) {
+      const newChurch: Church = { id: `${Date.now()}`, ...church };
+      this.fallback.push(newChurch);
+      return of(newChurch);
+    }
+    return this.http.post<Church>(this.baseUrl, church);
+  }
+}

--- a/src/app/services/prayer-request-api.service.ts
+++ b/src/app/services/prayer-request-api.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { environment } from '../../environments/environment';
+import { PrayerRequest } from '../models/prayer-request';
+
+@Injectable({ providedIn: 'root' })
+export class PrayerRequestApiService {
+  private apiEnabled = !!environment.apiUrl;
+  private readonly baseUrl = `${environment.apiUrl}/prayerRequests`;
+  private fallback: PrayerRequest[] = [];
+
+  constructor(private http: HttpClient) {}
+
+  list(): Observable<PrayerRequest[]> {
+    if (!this.apiEnabled) {
+      return of(this.fallback);
+    }
+    return this.http.get<PrayerRequest[]>(this.baseUrl);
+  }
+
+  create(req: { userId: string; text: string }): Observable<PrayerRequest> {
+    if (!this.apiEnabled) {
+      const newReq: PrayerRequest = {
+        id: `${Date.now()}`,
+        createdAt: new Date().toISOString(),
+        prayedAt: null,
+        ...req,
+      };
+      this.fallback.push(newReq);
+      return of(newReq);
+    }
+    return this.http.post<PrayerRequest>(this.baseUrl, req);
+  }
+
+  markPrayed(id: string): Observable<{ id: string; prayedAt: string }> {
+      if (!this.apiEnabled) {
+        const timestamp = new Date().toISOString();
+        const req = this.fallback.find(r => r.id === id);
+        if (req) {
+          req.prayedAt = timestamp;
+        }
+        return of({ id, prayedAt: timestamp });
+      }
+      return this.http.patch<{ id: string; prayedAt: string }>(`${this.baseUrl}/${id}/prayed`, {});
+  }
+}


### PR DESCRIPTION
## Summary
- add Church API service and standalone churches page to list and create churches
- add Prayer Request API service and bulletin page to manage requests
- register new pages in router and main menu

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless --progress=false` *(fails: No binary for ChromeHeadless browser on your platform)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa0e84524c83279816166da7bef5a1