### PR TITLE
feat: extend prayer requests and church services

### DIFF
--- a/src/app/models/prayer-request.ts
+++ b/src/app/models/prayer-request.ts
@@ -2,6 +2,12 @@ export interface PrayerRequest {
   id?: string;
   userId: string;
   text: string;
+  birthday?: string | null;
+  timeZone?: string | null;
+  gender?: string | null;
+  age?: number;
+  ageGroup?: string;
+  color?: string;
   createdAt?: string;
   prayedAt?: string | null;
 }

--- a/src/app/prayer-bulletin/prayer-bulletin.page.html
+++ b/src/app/prayer-bulletin/prayer-bulletin.page.html
@@ -6,10 +6,11 @@
 
 <ion-content>
   <ion-list>
-    <ion-item *ngFor="let req of requests">
+    <ion-item *ngFor="let req of requests" [style.border-left]="'4px solid ' + req.color">
       <ion-label>
         <h3>{{ req.text }}</h3>
         <p>ID: {{ req.userId }}</p>
+        <p *ngIf="req.age !== undefined">Age: {{ req.age }} ({{ req.ageGroup }})</p>
         <p *ngIf="req.prayedAt">Prayed at: {{ req.prayedAt | date:'short' }}</p>
       </ion-label>
       <ion-button slot="end" *ngIf="!req.prayedAt" (click)="markPrayed(req)">Mark Prayed</ion-button>
@@ -21,6 +22,15 @@
   </ion-item>
   <ion-item>
     <ion-input placeholder="Prayer request" [(ngModel)]="text"></ion-input>
+  </ion-item>
+  <ion-item>
+    <ion-input type="date" placeholder="Birthday" [(ngModel)]="birthday"></ion-input>
+  </ion-item>
+  <ion-item>
+    <ion-input placeholder="Time Zone" [(ngModel)]="timeZone"></ion-input>
+  </ion-item>
+  <ion-item>
+    <ion-input placeholder="Gender" [(ngModel)]="gender"></ion-input>
   </ion-item>
   <ion-button expand="block" (click)="add()">Add Request</ion-button>
 </ion-content>

--- a/src/app/prayer-bulletin/prayer-bulletin.page.ts
+++ b/src/app/prayer-bulletin/prayer-bulletin.page.ts
@@ -29,6 +29,9 @@ export class PrayerBulletinPage {
   requests: PrayerRequest[] = [];
   userId = '';
   text = '';
+  birthday = '';
+  timeZone = '';
+  gender = '';
 
   constructor(private api: PrayerRequestApiService) {}
 
@@ -44,11 +47,22 @@ export class PrayerBulletinPage {
     if (!this.userId || !this.text) {
       return;
     }
-    this.api.create({ userId: this.userId, text: this.text }).subscribe((r) => {
-      this.requests.push(r);
-      this.userId = '';
-      this.text = '';
-    });
+    this.api
+      .create({
+        userId: this.userId,
+        text: this.text,
+        birthday: this.birthday || null,
+        timeZone: this.timeZone || null,
+        gender: this.gender || null,
+      })
+      .subscribe((r) => {
+        this.requests.push(r);
+        this.userId = '';
+        this.text = '';
+        this.birthday = '';
+        this.timeZone = '';
+        this.gender = '';
+      });
   }
 
   markPrayed(req: PrayerRequest): void {

--- a/src/app/services/church-api.service.ts
+++ b/src/app/services/church-api.service.ts
@@ -27,4 +27,23 @@ export class ChurchApiService {
     }
     return this.http.post<Church>(this.baseUrl, church);
   }
+
+  get(id: string): Observable<Church> {
+    if (!this.apiEnabled) {
+      const church = this.fallback.find((c) => c.id === id);
+      return of(church as Church);
+    }
+    return this.http.get<Church>(`${this.baseUrl}/${id}`);
+  }
+
+  update(id: string, updates: { name?: string; logoUrl?: string }): Observable<Church> {
+    if (!this.apiEnabled) {
+      const church = this.fallback.find((c) => c.id === id);
+      if (church) {
+        Object.assign(church, updates);
+      }
+      return of({ id, ...(church as Church) });
+    }
+    return this.http.patch<Church>(`${this.baseUrl}/${id}`, updates);
+  }
 }

--- a/src/app/services/prayer-request-api.service.ts
+++ b/src/app/services/prayer-request-api.service.ts
@@ -19,7 +19,13 @@ export class PrayerRequestApiService {
     return this.http.get<PrayerRequest[]>(this.baseUrl);
   }
 
-  create(req: { userId: string; text: string }): Observable<PrayerRequest> {
+  create(req: {
+    userId: string;
+    text: string;
+    birthday?: string | null;
+    timeZone?: string | null;
+    gender?: string | null;
+  }): Observable<PrayerRequest> {
     if (!this.apiEnabled) {
       const newReq: PrayerRequest = {
         id: `${Date.now()}`,
@@ -31,6 +37,25 @@ export class PrayerRequestApiService {
       return of(newReq);
     }
     return this.http.post<PrayerRequest>(this.baseUrl, req);
+  }
+
+  update(
+    id: string,
+    updates: {
+      text?: string;
+      birthday?: string | null;
+      timeZone?: string | null;
+      gender?: string | null;
+    }
+  ): Observable<PrayerRequest> {
+    if (!this.apiEnabled) {
+      const req = this.fallback.find((r) => r.id === id);
+      if (req) {
+        Object.assign(req, updates);
+      }
+      return of({ id, ...(req as PrayerRequest) });
+    }
+    return this.http.patch<PrayerRequest>(`${this.baseUrl}/${id}`, updates);
   }
 
   markPrayed(id: string): Observable<{ id: string; prayedAt: string }> {


### PR DESCRIPTION
## Summary
- allow creating and listing prayer requests with birthday, time zone, gender and computed age details
- expose get/update church endpoints in API service
- color-code and show age group data for prayer bulletin requests

## Testing
- `npm test` *(fails: sh: 1: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa22ef206083278eb025ba8c036640