### PR TITLE
Allow adding churches without logo

### DIFF
--- a/src/app/churches/churches.page.html
+++ b/src/app/churches/churches.page.html
@@ -8,7 +8,10 @@
   <ion-list>
     <ion-item *ngFor="let church of churches">
       <ion-avatar slot="start">
-        <img [src]="church.logoUrl" alt="{{ church.name }} logo" />
+        <img
+          [src]="church.logoUrl || 'assets/icon/favicon.png'"
+          alt="{{ church.name }} logo"
+        />
       </ion-avatar>
       <ion-label>{{ church.name }}</ion-label>
     </ion-item>

--- a/src/app/churches/churches.page.ts
+++ b/src/app/churches/churches.page.ts
@@ -41,10 +41,14 @@ export class ChurchesPage {
   }
 
   add(): void {
-    if (!this.name || !this.logoUrl) {
+    if (!this.name) {
       return;
     }
-    this.api.create({ name: this.name, logoUrl: this.logoUrl }).subscribe((c) => {
+    const payload: { name: string; logoUrl?: string } = { name: this.name };
+    if (this.logoUrl) {
+      payload.logoUrl = this.logoUrl;
+    }
+    this.api.create(payload).subscribe((c) => {
       this.churches.push(c);
       this.name = '';
       this.logoUrl = '';

--- a/src/app/models/church.ts
+++ b/src/app/models/church.ts
@@ -1,6 +1,6 @@
 export interface Church {
   id?: string;
   name: string;
-  logoUrl: string;
+  logoUrl?: string;
   createdAt?: string;
 }

--- a/src/app/services/church-api.service.ts
+++ b/src/app/services/church-api.service.ts
@@ -19,7 +19,7 @@ export class ChurchApiService {
     return this.http.get<Church[]>(this.baseUrl);
   }
 
-  create(church: { name: string; logoUrl: string }): Observable<Church> {
+  create(church: { name: string; logoUrl?: string }): Observable<Church> {
     if (!this.apiEnabled) {
       const newChurch: Church = { id: `${Date.now()}`, ...church };
       this.fallback.push(newChurch);


### PR DESCRIPTION
## Summary
- Make church `logoUrl` optional across models and service
- Allow adding a church with only a name and supply default logo

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa27b3236c83278fcc30c7778c8379