### PR TITLE
feat: enhance prayer bulletin and church logo upload

### DIFF
--- a/src/app/churches/churches.page.html
+++ b/src/app/churches/churches.page.html
@@ -21,7 +21,7 @@
     <ion-input placeholder="Church Name" [(ngModel)]="name"></ion-input>
   </ion-item>
   <ion-item>
-    <ion-input placeholder="Logo URL" [(ngModel)]="logoUrl"></ion-input>
+    <input type="file" (change)="onLogoFileChange($event)" />
   </ion-item>
   <ion-button expand="block" (click)="add()">Add Church</ion-button>
 </ion-content>

--- a/src/app/churches/churches.page.ts
+++ b/src/app/churches/churches.page.ts
@@ -54,4 +54,16 @@ export class ChurchesPage {
       this.logoUrl = '';
     });
   }
+
+  onLogoFileChange(event: Event): void {
+    const file = (event.target as HTMLInputElement).files?.[0];
+    if (!file) {
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      this.logoUrl = reader.result as string;
+    };
+    reader.readAsDataURL(file);
+  }
 }

--- a/src/app/prayer-bulletin/prayer-bulletin.page.html
+++ b/src/app/prayer-bulletin/prayer-bulletin.page.html
@@ -6,15 +6,60 @@
 
 <ion-content>
   <ion-list>
-    <ion-item *ngFor="let req of requests" [style.border-left]="'4px solid ' + req.color">
-      <ion-label>
-        <h3>{{ req.text }}</h3>
-        <p>ID: {{ req.userId }}</p>
-        <p *ngIf="req.age !== undefined">Age: {{ req.age }} ({{ req.ageGroup }})</p>
-        <p *ngIf="req.prayedAt">Prayed at: {{ req.prayedAt | date:'short' }}</p>
-      </ion-label>
-      <ion-button slot="end" *ngIf="!req.prayedAt" (click)="markPrayed(req)">Mark Prayed</ion-button>
-    </ion-item>
+    <ng-container *ngFor="let group of groups">
+      <ion-item lines="full">
+        <ion-label><strong>ID: {{ group.userId }}</strong></ion-label>
+        <ion-button
+          slot="end"
+          size="small"
+          (click)="markAllForUser(group.userId)"
+          >Mark All Prayed</ion-button
+        >
+      </ion-item>
+      <ion-item
+        *ngFor="let req of group.requests"
+        [style.border-left]="'4px solid ' + req.color"
+      >
+        <ion-label>
+          <div *ngIf="!editing[req.id!]">
+            <h3>{{ req.text }}</h3>
+          </div>
+          <ion-input *ngIf="editing[req.id!]" [(ngModel)]="editText[req.id!]"
+          ></ion-input>
+          <p *ngIf="req.age !== undefined">
+            Age: {{ req.age }} ({{ req.ageGroup }})
+          </p>
+          <p *ngIf="req.prayedAt">Prayed at: {{ req.prayedAt | date: 'short' }}</p>
+        </ion-label>
+        <ion-button
+          slot="end"
+          *ngIf="!req.prayedAt && !editing[req.id!]"
+          (click)="markPrayed(req)"
+          >Mark Prayed</ion-button
+        >
+        <ion-button
+          slot="end"
+          color="medium"
+          *ngIf="!editing[req.id!]"
+          (click)="startEdit(req)"
+          >Edit</ion-button
+        >
+        <ion-button
+          slot="end"
+          color="success"
+          *ngIf="editing[req.id!]"
+          (click)="save(req)"
+          >Save</ion-button
+        >
+        <ion-button
+          slot="end"
+          color="light"
+          *ngIf="editing[req.id!]"
+          (click)="cancelEdit(req)"
+          >Cancel</ion-button
+        >
+      </ion-item>
+    </ng-container>
   </ion-list>
 
   <ion-item>

--- a/src/app/prayer-bulletin/prayer-bulletin.page.ts
+++ b/src/app/prayer-bulletin/prayer-bulletin.page.ts
@@ -1,7 +1,17 @@
 import { Component } from '@angular/core';
-import { IonHeader, IonToolbar, IonTitle, IonContent, IonList, IonItem, IonLabel, IonInput, IonButton } from '@ionic/angular/standalone';
+import {
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonContent,
+  IonList,
+  IonItem,
+  IonLabel,
+  IonInput,
+  IonButton,
+} from '@ionic/angular/standalone';
 import { FormsModule } from '@angular/forms';
-import { NgFor, DatePipe } from '@angular/common';
+import { NgFor, NgIf, DatePipe } from '@angular/common';
 import { PrayerRequestApiService } from '../services/prayer-request-api.service';
 import { PrayerRequest } from '../models/prayer-request';
 
@@ -22,6 +32,7 @@ import { PrayerRequest } from '../models/prayer-request';
     IonButton,
     FormsModule,
     NgFor,
+    NgIf,
     DatePipe,
   ],
 })
@@ -33,6 +44,9 @@ export class PrayerBulletinPage {
   timeZone = '';
   gender = '';
 
+  editing: Record<string, boolean> = {};
+  editText: Record<string, string> = {};
+
   constructor(private api: PrayerRequestApiService) {}
 
   ionViewWillEnter(): void {
@@ -40,7 +54,11 @@ export class PrayerBulletinPage {
   }
 
   load(): void {
-    this.api.list().subscribe((rs) => (this.requests = rs));
+    this.api.list().subscribe((rs) => {
+      this.requests = rs
+        .map((r) => this.enrichRequest(r))
+        .filter((r) => !this.isExpired(r));
+    });
   }
 
   add(): void {
@@ -56,6 +74,7 @@ export class PrayerBulletinPage {
         gender: this.gender || null,
       })
       .subscribe((r) => {
+        this.enrichRequest(r);
         this.requests.push(r);
         this.userId = '';
         this.text = '';
@@ -71,6 +90,73 @@ export class PrayerBulletinPage {
     }
     this.api.markPrayed(req.id).subscribe((res) => {
       req.prayedAt = res.prayedAt;
+      if (this.isExpired(req)) {
+        this.requests = this.requests.filter((r) => r.id !== req.id);
+      }
     });
+  }
+
+  startEdit(req: PrayerRequest): void {
+    if (!req.id) {
+      return;
+    }
+    this.editing[req.id] = true;
+    this.editText[req.id] = req.text;
+  }
+
+  cancelEdit(req: PrayerRequest): void {
+    if (req.id) {
+      this.editing[req.id] = false;
+    }
+  }
+
+  save(req: PrayerRequest): void {
+    if (!req.id) {
+      return;
+    }
+    const text = this.editText[req.id];
+    this.api.update(req.id, { text }).subscribe((updated) => {
+      req.text = updated.text;
+      this.editing[req.id!] = false;
+    });
+  }
+
+  markAllForUser(userId: string): void {
+    this.requests
+      .filter((r) => r.userId === userId && !r.prayedAt)
+      .forEach((r) => this.markPrayed(r));
+  }
+
+  get groups(): { userId: string; requests: PrayerRequest[] }[] {
+    const map: Record<string, PrayerRequest[]> = {};
+    for (const r of this.requests) {
+      if (!map[r.userId]) {
+        map[r.userId] = [];
+      }
+      map[r.userId].push(r);
+    }
+    return Object.entries(map).map(([userId, requests]) => ({ userId, requests }));
+  }
+
+  private enrichRequest(req: PrayerRequest): PrayerRequest {
+    if (req.birthday) {
+      const birth = new Date(req.birthday);
+      const age = Math.floor(
+        (Date.now() - birth.getTime()) / (365.25 * 24 * 60 * 60 * 1000)
+      );
+      req.age = age;
+      req.ageGroup = age >= 18 ? 'Adult' : 'Child';
+      req.color = age >= 18 ? 'purple' : 'blue';
+    } else {
+      req.color = 'blue';
+    }
+    return req;
+  }
+
+  private isExpired(req: PrayerRequest): boolean {
+    return (
+      !!req.prayedAt &&
+      new Date(req.prayedAt).getTime() < Date.now() - 7 * 24 * 60 * 60 * 1000
+    );
   }
 }


### PR DESCRIPTION
## Summary
- group and edit prayer requests with age-based coloring
- auto-expire prayed requests after a week
- allow churches to upload logo files when signing up

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4259db988327aec03fb9da3a6acb