### PR TITLE
feat: manage churches and prayer requests

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -62,11 +62,11 @@
             <ion-icon slot="start" name="trophy-outline"></ion-icon>
             <ion-label>Leaderboard</ion-label>
           </ion-item>
-          <ion-item routerLink="/tabs/churches">
+          <ion-item routerLink="/tabs/churches" *ngIf="role === 'admin' || role === 'church'">
             <ion-icon slot="start" name="business-outline"></ion-icon>
             <ion-label>Churches</ion-label>
           </ion-item>
-          <ion-item routerLink="/tabs/prayer-bulletin">
+          <ion-item routerLink="/tabs/prayer-bulletin" *ngIf="role === 'admin' || role === 'church'">
             <ion-icon slot="start" name="newspaper-outline"></ion-icon>
             <ion-label>Prayer Bulletin</ion-label>
           </ion-item>

--- a/src/app/churches/churches.page.html
+++ b/src/app/churches/churches.page.html
@@ -9,19 +9,39 @@
     <ion-item *ngFor="let church of churches">
       <ion-avatar slot="start">
         <img
-          [src]="church.logoUrl || 'assets/icon/favicon.png'"
+          [src]="
+            editing[church.id!]
+              ? editLogoUrl[church.id!] || church.logoUrl || 'assets/icon/favicon.png'
+              : church.logoUrl || 'assets/icon/favicon.png'
+          "
           alt="{{ church.name }} logo"
         />
       </ion-avatar>
-      <ion-label>{{ church.name }}</ion-label>
+
+      <ng-container *ngIf="!editing[church.id!]; else editBlock">
+        <ion-label>{{ church.name }}</ion-label>
+      </ng-container>
+      <ng-template #editBlock>
+        <ion-input [(ngModel)]="editName[church.id!]"></ion-input>
+        <input type="file" (change)="onEditLogoFileChange($event, church)" />
+      </ng-template>
+
+      <ng-container *ngIf="role === 'admin'">
+        <ion-button *ngIf="!editing[church.id!]" slot="end" (click)="startEdit(church)">Edit</ion-button>
+        <ion-button *ngIf="!editing[church.id!]" color="danger" slot="end" (click)="remove(church)">Delete</ion-button>
+        <ion-button *ngIf="editing[church.id!]" color="success" slot="end" (click)="save(church)">Save</ion-button>
+        <ion-button *ngIf="editing[church.id!]" color="medium" slot="end" (click)="cancelEdit(church)">Cancel</ion-button>
+      </ng-container>
     </ion-item>
   </ion-list>
 
-  <ion-item>
-    <ion-input placeholder="Church Name" [(ngModel)]="name"></ion-input>
-  </ion-item>
-  <ion-item>
-    <input type="file" (change)="onLogoFileChange($event)" />
-  </ion-item>
-  <ion-button expand="block" (click)="add()">Add Church</ion-button>
+  <ng-container *ngIf="role === 'admin'">
+    <ion-item>
+      <ion-input placeholder="Church Name" [(ngModel)]="name"></ion-input>
+    </ion-item>
+    <ion-item>
+      <input type="file" (change)="onLogoFileChange($event)" />
+    </ion-item>
+    <ion-button expand="block" (click)="add()">Add Church</ion-button>
+  </ng-container>
 </ion-content>

--- a/src/app/churches/churches.page.ts
+++ b/src/app/churches/churches.page.ts
@@ -1,9 +1,22 @@
 import { Component } from '@angular/core';
-import { IonHeader, IonToolbar, IonTitle, IonContent, IonList, IonItem, IonLabel, IonInput, IonButton, IonAvatar } from '@ionic/angular/standalone';
+import {
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonContent,
+  IonList,
+  IonItem,
+  IonLabel,
+  IonInput,
+  IonButton,
+  IonAvatar,
+} from '@ionic/angular/standalone';
 import { FormsModule } from '@angular/forms';
-import { NgFor } from '@angular/common';
+import { NgFor, NgIf } from '@angular/common';
 import { ChurchApiService } from '../services/church-api.service';
 import { Church } from '../models/church';
+import { RoleService } from '../services/role.service';
+import { FirebaseService } from '../services/firebase.service';
 
 @Component({
   selector: 'app-churches',
@@ -23,21 +36,42 @@ import { Church } from '../models/church';
     IonAvatar,
     FormsModule,
     NgFor,
+    NgIf,
   ],
 })
 export class ChurchesPage {
   churches: Church[] = [];
   name = '';
   logoUrl = '';
+  role: string | null = null;
 
-  constructor(private api: ChurchApiService) {}
+  editing: Record<string, boolean> = {};
+  editName: Record<string, string> = {};
+  editLogoUrl: Record<string, string> = {};
+
+  constructor(
+    private api: ChurchApiService,
+    private roleSvc: RoleService,
+    private fb: FirebaseService
+  ) {
+    this.roleSvc.role$.subscribe((r) => (this.role = r));
+  }
 
   ionViewWillEnter(): void {
     this.load();
   }
 
   load(): void {
-    this.api.list().subscribe((cs) => (this.churches = cs));
+    if (this.role === 'church') {
+      const uid = this.fb.auth.currentUser?.uid;
+      if (uid) {
+        this.api.get(uid).subscribe((c) => (this.churches = c ? [c] : []));
+      } else {
+        this.churches = [];
+      }
+    } else {
+      this.api.list().subscribe((cs) => (this.churches = cs));
+    }
   }
 
   add(): void {
@@ -55,6 +89,47 @@ export class ChurchesPage {
     });
   }
 
+  startEdit(c: Church): void {
+    if (!c.id) {
+      return;
+    }
+    this.editing[c.id] = true;
+    this.editName[c.id] = c.name;
+    this.editLogoUrl[c.id] = c.logoUrl || '';
+  }
+
+  cancelEdit(c: Church): void {
+    if (c.id) {
+      this.editing[c.id] = false;
+    }
+  }
+
+  save(c: Church): void {
+    if (!c.id) {
+      return;
+    }
+    const payload: { name?: string; logoUrl?: string } = {
+      name: this.editName[c.id],
+    };
+    if (this.editLogoUrl[c.id]) {
+      payload.logoUrl = this.editLogoUrl[c.id];
+    }
+    this.api.update(c.id, payload).subscribe((updated) => {
+      c.name = updated.name;
+      c.logoUrl = updated.logoUrl;
+      this.editing[c.id!] = false;
+    });
+  }
+
+  remove(c: Church): void {
+    if (!c.id) {
+      return;
+    }
+    this.api.delete(c.id).subscribe(() => {
+      this.churches = this.churches.filter((ch) => ch.id !== c.id);
+    });
+  }
+
   onLogoFileChange(event: Event): void {
     const file = (event.target as HTMLInputElement).files?.[0];
     if (!file) {
@@ -63,6 +138,18 @@ export class ChurchesPage {
     const reader = new FileReader();
     reader.onload = () => {
       this.logoUrl = reader.result as string;
+    };
+    reader.readAsDataURL(file);
+  }
+
+  onEditLogoFileChange(event: Event, c: Church): void {
+    const file = (event.target as HTMLInputElement).files?.[0];
+    if (!file || !c.id) {
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      this.editLogoUrl[c.id!] = reader.result as string;
     };
     reader.readAsDataURL(file);
   }

--- a/src/app/prayer-bulletin/prayer-bulletin.page.html
+++ b/src/app/prayer-bulletin/prayer-bulletin.page.html
@@ -6,26 +6,71 @@
 
 <ion-content>
   <ion-list>
-    <ng-container *ngFor="let group of groups">
-      <ion-item lines="full">
-        <ion-label><strong>ID: {{ group.userId }}</strong></ion-label>
-        <ion-button
-          slot="end"
-          size="small"
-          (click)="markAllForUser(group.userId)"
-          >Mark All Prayed</ion-button
+    <ng-container *ngIf="role !== 'church'; else churchList">
+      <ng-container *ngFor="let group of groups">
+        <ion-item lines="full">
+          <ion-label><strong>ID: {{ group.userId }}</strong></ion-label>
+          <ion-button
+            slot="end"
+            size="small"
+            (click)="markAllForUser(group.userId)"
+            >Mark All Prayed</ion-button
+          >
+        </ion-item>
+        <ion-item
+          *ngFor="let req of group.requests"
+          [style.border-left]="'4px solid ' + req.color"
         >
-      </ion-item>
+          <ion-label>
+            <div *ngIf="!editing[req.id!]">
+              <h3>{{ req.text }}</h3>
+            </div>
+            <ion-input *ngIf="editing[req.id!]" [(ngModel)]="editText[req.id!]"></ion-input>
+            <p *ngIf="req.age !== undefined">
+              Age: {{ req.age }} ({{ req.ageGroup }})
+            </p>
+            <p *ngIf="req.prayedAt">Prayed at: {{ req.prayedAt | date: 'short' }}</p>
+          </ion-label>
+          <ion-button
+            slot="end"
+            *ngIf="!req.prayedAt && !editing[req.id!]"
+            (click)="markPrayed(req)"
+            >Mark Prayed</ion-button
+          >
+          <ion-button
+            slot="end"
+            color="medium"
+            *ngIf="!editing[req.id!]"
+            (click)="startEdit(req)"
+            >Edit</ion-button
+          >
+          <ion-button
+            slot="end"
+            color="success"
+            *ngIf="editing[req.id!]"
+            (click)="save(req)"
+            >Save</ion-button
+          >
+          <ion-button
+            slot="end"
+            color="light"
+            *ngIf="editing[req.id!]"
+            (click)="cancelEdit(req)"
+            >Cancel</ion-button
+          >
+        </ion-item>
+      </ng-container>
+    </ng-container>
+    <ng-template #churchList>
       <ion-item
-        *ngFor="let req of group.requests"
+        *ngFor="let req of requests"
         [style.border-left]="'4px solid ' + req.color"
       >
         <ion-label>
           <div *ngIf="!editing[req.id!]">
             <h3>{{ req.text }}</h3>
           </div>
-          <ion-input *ngIf="editing[req.id!]" [(ngModel)]="editText[req.id!]"
-          ></ion-input>
+          <ion-input *ngIf="editing[req.id!]" [(ngModel)]="editText[req.id!]"></ion-input>
           <p *ngIf="req.age !== undefined">
             Age: {{ req.age }} ({{ req.ageGroup }})
           </p>
@@ -59,10 +104,10 @@
           >Cancel</ion-button
         >
       </ion-item>
-    </ng-container>
+    </ng-template>
   </ion-list>
 
-  <ion-item>
+  <ion-item *ngIf="role !== 'church'">
     <ion-input placeholder="Your ID" [(ngModel)]="userId"></ion-input>
   </ion-item>
   <ion-item>

--- a/src/app/services/church-api.service.ts
+++ b/src/app/services/church-api.service.ts
@@ -46,4 +46,12 @@ export class ChurchApiService {
     }
     return this.http.patch<Church>(`${this.baseUrl}/${id}`, updates);
   }
+
+  delete(id: string): Observable<void> {
+    if (!this.apiEnabled) {
+      this.fallback = this.fallback.filter((c) => c.id !== id);
+      return of(void 0);
+    }
+    return this.http.delete<void>(`${this.baseUrl}/${id}`);
+  }
 }


### PR DESCRIPTION
## Summary
- allow admins to manage churches by adding, editing, or removing entries
- restrict churches to view their profile and related prayer requests only
- show church and prayer bulletin menu links only to admins or churches

## Testing
- `npm test` *(fails: sh: 1: ng: not found)*
- `npm run lint` *(fails: sh: 1: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa493c09888327af0f6b145508dd8d