### PR TITLE
Add church role with prayer bulletin redirect

### DIFF
--- a/src/app/login/login.page.html
+++ b/src/app/login/login.page.html
@@ -35,6 +35,7 @@
         <ion-select-option value="parent">Parent</ion-select-option>
         <ion-select-option value="child">Child</ion-select-option>
         <ion-select-option value="mentor">Mentor</ion-select-option>
+        <ion-select-option value="church">Church</ion-select-option>
         <ion-select-option value="admin">Admin</ion-select-option>
       </ion-select>
     </ion-item>

--- a/src/app/login/login.page.ts
+++ b/src/app/login/login.page.ts
@@ -57,7 +57,9 @@ export class LoginPage {
         position: 'bottom',
       });
       await toast.present();
-      this.router.navigateByUrl('/tabs');
+      const target =
+        this.selectedRole === 'church' ? '/tabs/prayer-bulletin' : '/tabs';
+      this.router.navigateByUrl(target);
     } catch (err: any) {
       const toast = await this.toastCtrl.create({
         message: err?.message || 'Login failed',
@@ -79,7 +81,9 @@ export class LoginPage {
         position: 'bottom',
       });
       await toast.present();
-      this.router.navigateByUrl('/tabs');
+      const target =
+        this.selectedRole === 'church' ? '/tabs/prayer-bulletin' : '/tabs';
+      this.router.navigateByUrl(target);
     } catch (err: any) {
       const toast = await this.toastCtrl.create({
         message: err?.message || 'Google login failed',


### PR DESCRIPTION
## Summary
- Allow selecting a new Church role on login
- Send Church users directly to the Prayer Bulletin after signing in

## Testing
- `npm test` *(fails: sh: 1: ng: not found)*
- `npm run lint` *(fails: sh: 1: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa60158e9883279365fdef0ab01668