### PR TITLE
Add gender and timezone dropdowns to prayer bulletin

### DIFF
--- a/src/app/prayer-bulletin/prayer-bulletin.page.html
+++ b/src/app/prayer-bulletin/prayer-bulletin.page.html
@@ -117,10 +117,20 @@
     <ion-input type="date" placeholder="Birthday" [(ngModel)]="birthday"></ion-input>
   </ion-item>
   <ion-item>
-    <ion-input placeholder="Time Zone" [(ngModel)]="timeZone"></ion-input>
+    <ion-select placeholder="Time Zone" [(ngModel)]="timeZone">
+      <ion-select-option
+        *ngFor="let tz of timeZones"
+        [value]="tz"
+        >{{ tz }}</ion-select-option
+      >
+    </ion-select>
   </ion-item>
   <ion-item>
-    <ion-input placeholder="Gender" [(ngModel)]="gender"></ion-input>
+    <ion-select placeholder="Gender" [(ngModel)]="gender">
+      <ion-select-option *ngFor="let g of genders" [value]="g"
+        >{{ g }}</ion-select-option
+      >
+    </ion-select>
   </ion-item>
   <ion-button expand="block" (click)="add()">Add Request</ion-button>
 </ion-content>

--- a/src/app/prayer-bulletin/prayer-bulletin.page.ts
+++ b/src/app/prayer-bulletin/prayer-bulletin.page.ts
@@ -9,6 +9,8 @@ import {
   IonLabel,
   IonInput,
   IonButton,
+  IonSelect,
+  IonSelectOption,
 } from '@ionic/angular/standalone';
 import { FormsModule } from '@angular/forms';
 import { NgFor, NgIf, DatePipe } from '@angular/common';
@@ -32,6 +34,8 @@ import { FirebaseService } from '../services/firebase.service';
     IonLabel,
     IonInput,
     IonButton,
+    IonSelect,
+    IonSelectOption,
     FormsModule,
     NgFor,
     NgIf,
@@ -46,6 +50,11 @@ export class PrayerBulletinPage {
   birthday = '';
   timeZone = '';
   gender = '';
+  timeZones: string[] =
+    (Intl as any).supportedValuesOf
+      ? (Intl as any).supportedValuesOf('timeZone')
+      : [];
+  genders: string[] = ['Male', 'Female'];
   role: string | null = null;
 
   editing: Record<string, boolean> = {};


### PR DESCRIPTION
## Summary
- add gender dropdown and time zone selector to prayer bulletin form
- provide time zone list using Intl.supportedValuesOf

## Testing
- `npm test` *(fails: ng: not found)*
- `npm run lint` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8bed60ec8327935c42d708349715