### PR TITLE
fix: correct api url paths to backend

### DIFF
--- a/src/app/services/bible-quiz-api.service.ts
+++ b/src/app/services/bible-quiz-api.service.ts
@@ -25,7 +25,7 @@ export class BibleQuizApiService {
 
     return this.http
       .get<BibleQuestion[]>(
-        `${environment.apiUrl}/api/quizzes/today?count=${count}`
+        `${environment.apiUrl}/quizzes/today?count=${count}`
       )
       .pipe(
         timeout(5000),
@@ -57,7 +57,7 @@ export class BibleQuizApiService {
       answers: [data.answer],
     };
     return this.http
-      .post(`${environment.apiUrl}/api/quizzes/submit`, payload)
+      .post(`${environment.apiUrl}/quizzes/submit`, payload)
       .pipe(
         timeout(5000),
         catchError(() => {
@@ -79,7 +79,7 @@ export class BibleQuizApiService {
     }
 
     return this.http
-      .get<BibleQuizResult[]>(`${environment.apiUrl}/api/quizzes/${childId}/history`)
+      .get<BibleQuizResult[]>(`${environment.apiUrl}/quizzes/${childId}/history`)
       .pipe(
         timeout(5000),
         catchError(() => from(this.fb.getBibleQuizHistory(childId)))

--- a/src/app/services/group-api.service.ts
+++ b/src/app/services/group-api.service.ts
@@ -9,7 +9,7 @@ import { FirebaseService } from './firebase.service';
 @Injectable({ providedIn: 'root' })
 export class GroupApiService {
   private apiEnabled = !!environment.apiUrl;
-  private readonly baseUrl = `${environment.apiUrl}/api/groups`;
+  private readonly baseUrl = `${environment.apiUrl}/groups`;
 
   constructor(private http: HttpClient, private fb: FirebaseService) {}
 

--- a/src/app/services/group.service.ts
+++ b/src/app/services/group.service.ts
@@ -7,7 +7,7 @@ import { Observable, from } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class GroupService {
-  private readonly baseUrl = `${environment.apiUrl}/api/groups`;
+  private readonly baseUrl = `${environment.apiUrl}/groups`;
   private groups: Group[] = [];
 
   constructor(private http: HttpClient, private fb: FirebaseService) {}

--- a/src/app/services/points-api.service.ts
+++ b/src/app/services/points-api.service.ts
@@ -9,7 +9,7 @@ import { UserStats } from '../models/user-stats';
 @Injectable({ providedIn: 'root' })
 export class PointsApiService {
   private apiEnabled = !!environment.apiUrl;
-  private readonly baseUrl = `${environment.apiUrl}/api/points`;
+  private readonly baseUrl = `${environment.apiUrl}/points`;
 
   constructor(private http: HttpClient, private fb: FirebaseService) {}
 


### PR DESCRIPTION
## Summary
- fix double `/api` segments in service URLs to stop 404 errors
- ensure group, points, and bible quiz API services use consistent base URLs

## Testing
- `npm test` *(fails: ng not found; dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf12db3d88327b14877825017bbcb