### PR TITLE
feat: add structured gratitude questions with mentor notifications

### DIFF
--- a/src/app/check-in/check-in.page.html
+++ b/src/app/check-in/check-in.page.html
@@ -8,16 +8,44 @@
   <ion-content>
   <ion-list>
     <ion-item>
-      <ion-label position="stacked">Gratitude 1</ion-label>
-      <ion-input [(ngModel)]="form.gratitude1"></ion-input>
+      <ion-label>Grateful for your talents or something new you've learned?</ion-label>
+      <ion-toggle [(ngModel)]="form.talent"></ion-toggle>
+    </ion-item>
+    <ion-item *ngIf="form.talent">
+      <ion-label position="stacked">What is it?</ion-label>
+      <ion-input [(ngModel)]="form.talentText"></ion-input>
     </ion-item>
     <ion-item>
-      <ion-label position="stacked">Gratitude 2</ion-label>
-      <ion-input [(ngModel)]="form.gratitude2"></ion-input>
+      <ion-label>Grateful for something about your home?</ion-label>
+      <ion-toggle [(ngModel)]="form.home"></ion-toggle>
+    </ion-item>
+    <ion-item *ngIf="form.home">
+      <ion-label position="stacked">What is it?</ion-label>
+      <ion-input [(ngModel)]="form.homeText"></ion-input>
     </ion-item>
     <ion-item>
-      <ion-label position="stacked">Gratitude 3</ion-label>
-      <ion-input [(ngModel)]="form.gratitude3"></ion-input>
+      <ion-label>Grateful for your physical being or health?</ion-label>
+      <ion-toggle [(ngModel)]="form.physical"></ion-toggle>
+    </ion-item>
+    <ion-item *ngIf="form.physical">
+      <ion-label position="stacked">What is it?</ion-label>
+      <ion-input [(ngModel)]="form.physicalText"></ion-input>
+    </ion-item>
+    <ion-item>
+      <ion-label>Grateful for caring people around you?</ion-label>
+      <ion-toggle [(ngModel)]="form.people"></ion-toggle>
+    </ion-item>
+    <ion-item *ngIf="form.people">
+      <ion-label position="stacked">What is it?</ion-label>
+      <ion-input [(ngModel)]="form.peopleText"></ion-input>
+    </ion-item>
+    <ion-item>
+      <ion-label>Did you make someone smile today?</ion-label>
+      <ion-toggle [(ngModel)]="form.giving"></ion-toggle>
+    </ion-item>
+    <ion-item *ngIf="form.giving">
+      <ion-label position="stacked">What did you do?</ion-label>
+      <ion-input [(ngModel)]="form.givingText"></ion-input>
     </ion-item>
     <ion-item>
       <ion-label position="stacked">One Wish</ion-label>

--- a/src/app/check-in/check-in.page.ts
+++ b/src/app/check-in/check-in.page.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import {  IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonTextarea, IonSegment, IonSegmentButton, IonCheckbox } from '@ionic/angular/standalone';
+import {  IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonItem, IonLabel, IonButton, IonList, IonTextarea, IonSegment, IonSegmentButton, IonCheckbox, IonToggle } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
 import { ToastController } from '@ionic/angular';
 import { DailyCheckin } from '../models/daily-checkin';
@@ -25,15 +25,26 @@ import { DailyCheckin } from '../models/daily-checkin';
     IonSegment,
     IonSegmentButton,
     IonCheckbox,
+    IonToggle,
   ],
   templateUrl: './check-in.page.html',
   styleUrls: ['./check-in.page.scss'],
 })
 export class CheckInPage {
-  form: Omit<DailyCheckin, 'childId' | 'parentId' | 'date'> = {
-    gratitude1: '',
-    gratitude2: '',
-    gratitude3: '',
+  form: Omit<
+    DailyCheckin,
+    'childId' | 'parentId' | 'mentorId' | 'date' | 'redFlags'
+  > = {
+    talent: false,
+    talentText: '',
+    home: false,
+    homeText: '',
+    physical: false,
+    physicalText: '',
+    people: false,
+    peopleText: '',
+    giving: false,
+    givingText: '',
     wish: '',
     goal: '',
     birthday: '',
@@ -49,13 +60,45 @@ export class CheckInPage {
 
   async submit() {
     const user = this.fbService.auth.currentUser;
-    const parentId = user ? await this.fbService.getParentIdForChild(user.uid) : null;
+    const parentId = user
+      ? await this.fbService.getParentIdForChild(user.uid)
+      : null;
+    const mentorId = user
+      ? await this.fbService.getMentorIdForChild(user.uid)
+      : null;
+    const redFlags: string[] = [];
+    if (!this.form.talent) {
+      redFlags.push('talent');
+    }
+    if (!this.form.home) {
+      redFlags.push('home');
+    }
+    if (!this.form.physical) {
+      redFlags.push('physical');
+    }
+    if (!this.form.people) {
+      redFlags.push('people');
+    }
+    if (!this.form.giving) {
+      redFlags.push('giving');
+    }
     await this.fbService.saveDailyCheckin({
       ...this.form,
+      redFlags,
       childId: user ? user.uid : null,
       parentId,
+      mentorId,
       date: new Date().toISOString(),
     });
+    if (redFlags.length) {
+      const message = `Child lacked gratitude for: ${redFlags.join(', ')}`;
+      if (parentId) {
+        await this.fbService.sendNotification(parentId, message);
+      }
+      if (mentorId) {
+        await this.fbService.sendMentorNotification(mentorId, message);
+      }
+    }
     const toast = await this.toastCtrl.create({
       message: 'Check-in saved',
       duration: 1500,

--- a/src/app/models/daily-checkin.ts
+++ b/src/app/models/daily-checkin.ts
@@ -1,7 +1,14 @@
 export interface DailyCheckin {
-  gratitude1: string;
-  gratitude2: string;
-  gratitude3: string;
+  talent: boolean;
+  talentText: string;
+  home: boolean;
+  homeText: string;
+  physical: boolean;
+  physicalText: string;
+  people: boolean;
+  peopleText: string;
+  giving: boolean;
+  givingText: string;
   wish: string;
   goal: string;
   birthday: string;
@@ -11,7 +18,10 @@ export interface DailyCheckin {
   treatment: string;
   needsHelp: boolean;
   helpRequest: string;
+  redFlags?: string[];
   childId?: string | null;
   parentId?: string | null;
+  mentorId?: string | null;
   date: string;
 }
+

--- a/src/app/models/notification.ts
+++ b/src/app/models/notification.ts
@@ -2,6 +2,7 @@ export interface AppNotification {
   id?: string;
   parentId?: string;
   childId?: string;
+  mentorId?: string;
   message: string;
   date: string;
 }


### PR DESCRIPTION
## Summary
- expand daily check-in with five gratitude prompts and yes/no toggles
- flag missing gratitude responses and notify linked parents and mentors
- extend notification model and Firebase service to support mentor alerts

## Testing
- `npm run lint` *(fails: ng: not found)*
- `npm test` *(fails: ng: not found)*
- `npx --no-install tsc --noEmit` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68ab38cf64408327bc2bd7058d11ba3d