### PR TITLE
fix: restore page scrolling

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -41,6 +41,11 @@
 //   --color: var(--ion-color-light);
 // }
 
+/* Ensure pages remain scrollable */
+ion-content {
+  overflow-y: auto;
+}
+
 ion-tab-bar {
   /* Use a light background so icons remain visible */
   --background: var(--ion-color-light);


### PR DESCRIPTION
## Summary
- ensure pages remain scrollable by forcing ion-content to allow vertical overflow

## Testing
- `npm test -- --watch=false` *(fails: sh: 1: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3c898528832798a93eae67e7f0ee