### PR TITLE
Expand mental health questionnaire

### DIFF
--- a/src/app/mental-status/mental-status.page.html
+++ b/src/app/mental-status/mental-status.page.html
@@ -1,28 +1,158 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Mental & Emotional Status</ion-title>
+  </ion-toolbar>
+</ion-header>
 
-  <ion-header>
-    <ion-toolbar>
-      <ion-title>Mental & Emotional Status</ion-title>
-    </ion-toolbar>
-  </ion-header>
-
-  <ion-content>
+<ion-content>
   <ion-list>
     <ion-item>
-      <ion-label>Well Treated at School</ion-label>
-      <ion-checkbox slot="start" [(ngModel)]="form.treatmentSchool"></ion-checkbox>
+      <ion-label position="stacked">How is everyone treating you at home?</ion-label>
+      <ion-select [(ngModel)]="form.treatmentHome">
+        <ion-select-option value="very_nice">Very nice</ion-select-option>
+        <ion-select-option value="so_so">So so</ion-select-option>
+        <ion-select-option value="yuck">Yuck</ion-select-option>
+        <ion-select-option value="no_comment">I prefer not to talk about it</ion-select-option>
+      </ion-select>
     </ion-item>
+
     <ion-item>
-      <ion-label>Well Treated at Home</ion-label>
-      <ion-checkbox slot="start" [(ngModel)]="form.treatmentHome"></ion-checkbox>
+      <ion-label position="stacked">How is everyone treating you at school?</ion-label>
+      <ion-select [(ngModel)]="form.treatmentSchool">
+        <ion-select-option value="very_nice">Very nice</ion-select-option>
+        <ion-select-option value="so_so">So so</ion-select-option>
+        <ion-select-option value="yuck">Yuck</ion-select-option>
+        <ion-select-option value="no_comment">I prefer not to talk about it</ion-select-option>
+      </ion-select>
     </ion-item>
+
     <ion-item>
-      <ion-label>Were you bullied?</ion-label>
-      <ion-checkbox slot="start" [(ngModel)]="form.bullied"></ion-checkbox>
+      <ion-label position="stacked">How are your teachers or adults during lectures?</ion-label>
+      <ion-select [(ngModel)]="form.teachersLectures">
+        <ion-select-option value="very_nice">Very nice</ion-select-option>
+        <ion-select-option value="so_so">So so</ion-select-option>
+        <ion-select-option value="yuck">Yuck</ion-select-option>
+        <ion-select-option value="no_comment">I prefer not to talk about it</ion-select-option>
+      </ion-select>
     </ion-item>
+
     <ion-item>
-      <ion-label>Notify Parent if bullied?</ion-label>
-      <ion-checkbox slot="start" [(ngModel)]="form.notifyParent"></ion-checkbox>
+      <ion-label position="stacked">How are your teachers or adults during recess?</ion-label>
+      <ion-select [(ngModel)]="form.teachersRecess">
+        <ion-select-option value="very_nice">Very nice</ion-select-option>
+        <ion-select-option value="so_so">So so</ion-select-option>
+        <ion-select-option value="yuck">Yuck</ion-select-option>
+        <ion-select-option value="no_comment">I prefer not to talk about it</ion-select-option>
+      </ion-select>
     </ion-item>
+
+    <ion-item>
+      <ion-label position="stacked">How are your teachers or adults during free time?</ion-label>
+      <ion-select [(ngModel)]="form.teachersFreeTime">
+        <ion-select-option value="very_nice">Very nice</ion-select-option>
+        <ion-select-option value="so_so">So so</ion-select-option>
+        <ion-select-option value="yuck">Yuck</ion-select-option>
+        <ion-select-option value="no_comment">I prefer not to talk about it</ion-select-option>
+      </ion-select>
+    </ion-item>
+
+    <ion-item>
+      <ion-label position="stacked">How are your teachers or adults during lunch time?</ion-label>
+      <ion-select [(ngModel)]="form.teachersLunchTime">
+        <ion-select-option value="very_nice">Very nice</ion-select-option>
+        <ion-select-option value="so_so">So so</ion-select-option>
+        <ion-select-option value="yuck">Yuck</ion-select-option>
+        <ion-select-option value="no_comment">I prefer not to talk about it</ion-select-option>
+      </ion-select>
+    </ion-item>
+
+    <ion-item>
+      <ion-label>Are you getting bullied at school?</ion-label>
+      <ion-select [(ngModel)]="form.bulliedSchool">
+        <ion-select-option [value]="true">Yes</ion-select-option>
+        <ion-select-option [value]="false">No</ion-select-option>
+      </ion-select>
+    </ion-item>
+
+    <ion-item>
+      <ion-label>Are you getting bullied in your neighbourhood?</ion-label>
+      <ion-select [(ngModel)]="form.bulliedNeighborhood">
+        <ion-select-option [value]="true">Yes</ion-select-option>
+        <ion-select-option [value]="false">No</ion-select-option>
+      </ion-select>
+    </ion-item>
+
+    <ion-item>
+      <ion-label>Are you getting bullied at home or church?</ion-label>
+      <ion-select [(ngModel)]="form.bulliedHome">
+        <ion-select-option [value]="true">Yes</ion-select-option>
+        <ion-select-option [value]="false">No</ion-select-option>
+      </ion-select>
+    </ion-item>
+
+    <ion-item *ngIf="form.bulliedSchool || form.bulliedNeighborhood || form.bulliedHome">
+      <ion-label>Have you discussed this with your parents?</ion-label>
+      <ion-select [(ngModel)]="form.discussedWithParents">
+        <ion-select-option [value]="true">Yes</ion-select-option>
+        <ion-select-option [value]="false">No</ion-select-option>
+      </ion-select>
+    </ion-item>
+
+    <ion-item>
+      <ion-label>Do you love your life?</ion-label>
+      <ion-select [(ngModel)]="form.loveLife">
+        <ion-select-option [value]="true">Yes</ion-select-option>
+        <ion-select-option [value]="false">No</ion-select-option>
+      </ion-select>
+    </ion-item>
+
+    <ion-item>
+      <ion-label>Have you thought about hurting anyone?</ion-label>
+      <ion-select [(ngModel)]="form.hurtOthers">
+        <ion-select-option [value]="true">Yes</ion-select-option>
+        <ion-select-option [value]="false">No</ion-select-option>
+      </ion-select>
+    </ion-item>
+
+    <ion-item>
+      <ion-label>Have you recently thought about hurting yourself or hated yourself?</ion-label>
+      <ion-select [(ngModel)]="form.hurtSelf">
+        <ion-select-option [value]="true">Yes</ion-select-option>
+        <ion-select-option [value]="false">No</ion-select-option>
+      </ion-select>
+    </ion-item>
+
+    <ion-item *ngIf="form.hurtSelf">
+      <ion-label>Have you thought about a plan to hurt yourself?</ion-label>
+      <ion-select [(ngModel)]="form.planHurtSelf">
+        <ion-select-option [value]="true">Yes</ion-select-option>
+        <ion-select-option [value]="false">No</ion-select-option>
+      </ion-select>
+    </ion-item>
+
+    <ion-item>
+      <ion-label position="stacked">How has your sleep been?</ion-label>
+      <ion-select [(ngModel)]="form.sleep">
+        <ion-select-option value="good_dreams">Full of good dreams</ion-select-option>
+        <ion-select-option value="no_dreams">No dream</ion-select-option>
+        <ion-select-option value="nightmares">Nightmares</ion-select-option>
+        <ion-select-option value="difficulty">I find it difficult to fall asleep every night</ion-select-option>
+      </ion-select>
+    </ion-item>
+
+    <ion-item>
+      <ion-label position="stacked">How is your appetite?</ion-label>
+      <ion-select [(ngModel)]="form.appetite">
+        <ion-select-option value="great">Great</ion-select-option>
+        <ion-select-option value="overeat">I overeat most of the time</ion-select-option>
+        <ion-select-option value="so_so">So so</ion-select-option>
+        <ion-select-option value="yuck">Yuck</ion-select-option>
+        <ion-select-option value="no_appetite">I don't feel like eating most of the time</ion-select-option>
+        <ion-select-option value="prefer_away">I prefer eating when I am away from home</ion-select-option>
+        <ion-select-option value="throw_up">When I am at home I feel like throwing up if I see food</ion-select-option>
+      </ion-select>
+    </ion-item>
+
     <ion-item>
       <ion-label position="stacked">Suggestions</ion-label>
       <ion-textarea [(ngModel)]="form.suggestions"></ion-textarea>
@@ -31,5 +161,4 @@
   <div class="ion-padding">
     <ion-button expand="block" (click)="submit()">Submit</ion-button>
   </div>
-  </ion-content>
-
+</ion-content>

--- a/src/app/mental-status/mental-status.page.ts
+++ b/src/app/mental-status/mental-status.page.ts
@@ -2,17 +2,16 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import {
-
   IonHeader,
   IonToolbar,
   IonTitle,
   IonContent,
   IonItem,
   IonLabel,
-  IonInput,
   IonList,
   IonButton,
-  IonCheckbox,
+  IonSelect,
+  IonSelectOption,
   IonTextarea,
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
@@ -32,22 +31,35 @@ import { ToastController } from '@ionic/angular';
     IonContent,
     IonItem,
     IonLabel,
-
     IonList,
     IonButton,
-    IonCheckbox,
+    IonSelect,
+    IonSelectOption,
     IonTextarea,
   ],
   templateUrl: './mental-status.page.html',
   styleUrls: ['./mental-status.page.scss'],
 })
 export class MentalStatusPage {
-  form: Omit<MentalStatus, 'childId' | 'parentId' | 'date'> = {
-    treatmentSchool: false,
-    treatmentHome: false,
-    bullied: false,
-    notifyParent: false,
+  form: Omit<MentalStatus, 'childId' | 'parentId' | 'mentorId' | 'date'> = {
+    treatmentHome: '',
+    treatmentSchool: '',
+    teachersLectures: '',
+    teachersRecess: '',
+    teachersFreeTime: '',
+    teachersLunchTime: '',
+    bulliedSchool: false,
+    bulliedNeighborhood: false,
+    bulliedHome: false,
+    discussedWithParents: false,
+    loveLife: true,
+    hurtOthers: false,
+    hurtSelf: false,
+    planHurtSelf: false,
+    sleep: '',
+    appetite: '',
     suggestions: '',
+    redFlag: false,
   };
 
   constructor(private fb: FirebaseService, private toastCtrl: ToastController) {}
@@ -55,10 +67,31 @@ export class MentalStatusPage {
   async submit() {
     const user = this.fb.auth.currentUser;
     const parentId = user ? await this.fb.getParentIdForChild(user.uid) : null;
+    const mentorId = user ? await this.fb.getMentorIdForChild(user.uid) : null;
+    const bulliedAny =
+      this.form.bulliedSchool ||
+      this.form.bulliedNeighborhood ||
+      this.form.bulliedHome;
+    this.form.redFlag =
+      this.form.treatmentHome === 'yuck' ||
+      this.form.treatmentSchool === 'yuck' ||
+      this.form.teachersLectures === 'yuck' ||
+      this.form.teachersRecess === 'yuck' ||
+      this.form.teachersFreeTime === 'yuck' ||
+      this.form.teachersLunchTime === 'yuck' ||
+      (bulliedAny && !this.form.discussedWithParents) ||
+      !this.form.loveLife ||
+      this.form.hurtOthers ||
+      this.form.hurtSelf ||
+      this.form.planHurtSelf ||
+      ['overeat', 'no_appetite', 'prefer_away', 'throw_up'].includes(
+        this.form.appetite
+      );
     await this.fb.saveMentalStatus({
       ...this.form,
       childId: user ? user.uid : null,
       parentId,
+      mentorId,
       date: new Date().toISOString(),
     });
     const toast = await this.toastCtrl.create({

--- a/src/app/models/mental-status.ts
+++ b/src/app/models/mental-status.ts
@@ -1,10 +1,24 @@
 export interface MentalStatus {
-  treatmentSchool: boolean;
-  treatmentHome: boolean;
-  bullied: boolean;
-  notifyParent: boolean;
+  treatmentHome: string;
+  treatmentSchool: string;
+  teachersLectures: string;
+  teachersRecess: string;
+  teachersFreeTime: string;
+  teachersLunchTime: string;
+  bulliedSchool: boolean;
+  bulliedNeighborhood: boolean;
+  bulliedHome: boolean;
+  discussedWithParents: boolean;
+  loveLife: boolean;
+  hurtOthers: boolean;
+  hurtSelf: boolean;
+  planHurtSelf: boolean;
+  sleep: string;
+  appetite: string;
   suggestions: string;
+  redFlag: boolean;
   childId?: string | null;
   parentId?: string | null;
+  mentorId?: string | null;
   date: string;
 }

--- a/src/app/services/firebase.service.ts
+++ b/src/app/services/firebase.service.ts
@@ -139,12 +139,19 @@ export class FirebaseService {
 
   async saveMentalStatus(data: MentalStatus) {
     const docRef = await addDoc(collection(this.db, 'mentalStatus'), data);
-    if (data.childId) {
+    if (data.childId && data.redFlag) {
       const parentId = await this.getParentIdForChild(data.childId);
-      if (parentId && (data.bullied || data.notifyParent)) {
+      if (parentId) {
         await this.sendNotification(
           parentId,
           'Your child reported a concern in mental status form.'
+        );
+      }
+      const mentorId = await this.getMentorIdForChild(data.childId);
+      if (mentorId) {
+        await this.sendMentorNotification(
+          mentorId,
+          'A child you mentor reported a concern in mental status form.'
         );
       }
     }


### PR DESCRIPTION
## Summary
- add detailed mental and emotional status questionnaire
- track red flags and include additional fields in mental status model
- notify parent and mentor when a concerning response is submitted

## Testing
- `npm test -- --watch=false` *(fails: ng: not found)*
- `npm run lint` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab40989438832798481d82968df08a