### PR TITLE
feat: expand academic progress form

### DIFF
--- a/src/app/academic-progress/academic-progress.page.html
+++ b/src/app/academic-progress/academic-progress.page.html
@@ -5,8 +5,20 @@
     </ion-toolbar>
   </ion-header>
 
-  <ion-content>
+<ion-content>
   <ion-list>
+    <ion-item>
+      <ion-label position="stacked">Favorite Subject This Week</ion-label>
+      <ion-input [(ngModel)]="form.favoriteSubject"></ion-input>
+    </ion-item>
+    <ion-item>
+      <ion-label position="stacked">Struggling Subject</ion-label>
+      <ion-input [(ngModel)]="form.strugglingSubject"></ion-input>
+    </ion-item>
+    <ion-item>
+      <ion-label>Needs Help?</ion-label>
+      <ion-checkbox slot="start" [(ngModel)]="form.needsHelp"></ion-checkbox>
+    </ion-item>
     <ion-item>
       <ion-label position="stacked">Test Score</ion-label>
       <ion-input type="number" [(ngModel)]="form.testScore"></ion-input>
@@ -16,8 +28,16 @@
       <ion-checkbox slot="start" [(ngModel)]="form.shareResult"></ion-checkbox>
     </ion-item>
     <ion-item>
-      <ion-label>Needs Help?</ion-label>
-      <ion-checkbox slot="start" [(ngModel)]="form.needsHelp"></ion-checkbox>
+      <ion-label>Completed Weekly Assignment?</ion-label>
+      <ion-checkbox slot="start" [(ngModel)]="form.completedWeeklyAssignment"></ion-checkbox>
+    </ion-item>
+    <ion-item>
+      <ion-label>Participating in Weekly Challenges?</ion-label>
+      <ion-checkbox slot="start" [(ngModel)]="form.participatingChallenges"></ion-checkbox>
+    </ion-item>
+    <ion-item>
+      <ion-label position="stacked">Challenges to Submit (0-6)</ion-label>
+      <ion-input type="number" [(ngModel)]="form.challengesToSubmit"></ion-input>
     </ion-item>
   </ion-list>
   <div class="ion-padding">

--- a/src/app/academic-progress/academic-progress.page.ts
+++ b/src/app/academic-progress/academic-progress.page.ts
@@ -43,6 +43,11 @@ export class AcademicProgressPage {
     testScore: null as number | null,
     shareResult: false,
     needsHelp: false,
+    favoriteSubject: '',
+    strugglingSubject: '',
+    completedWeeklyAssignment: false,
+    participatingChallenges: false,
+    challengesToSubmit: null as number | null,
   };
 
   constructor(private fb: FirebaseService, private toastCtrl: ToastController) {}

--- a/src/app/models/academic-progress.ts
+++ b/src/app/models/academic-progress.ts
@@ -2,6 +2,11 @@ export interface AcademicProgressEntry {
   testScore: number | null;
   shareResult: boolean;
   needsHelp: boolean;
+  favoriteSubject: string;
+  strugglingSubject: string;
+  completedWeeklyAssignment: boolean;
+  participatingChallenges: boolean;
+  challengesToSubmit: number | null;
   childId?: string | null;
   date: string;
 }


### PR DESCRIPTION
## Summary
- capture favorite and struggling subjects, assignment completion, and challenge participation in academic progress tracking
- extend model and form to store weekly challenge submissions

## Testing
- `npm run lint` *(fails: ng: not found)*
- `npm test` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab564d5fc88327ae49b801cc00b267