### PR TITLE
feat: add book tracking to project tracker

### DIFF
--- a/src/app/models/project-entry.ts
+++ b/src/app/models/project-entry.ts
@@ -4,6 +4,8 @@ export interface ProjectEntry {
   needsHelp: boolean;
   enjoyment: number;
   progress: string;
+  bookTitle: string;
+  bookSummary: string;
   quarter: string;
   childId?: string | null;
   date: string;

--- a/src/app/project-tracker/project-tracker.page.html
+++ b/src/app/project-tracker/project-tracker.page.html
@@ -18,6 +18,16 @@
       </ion-item>
 
       <ion-item>
+        <ion-label position="stacked">Book Title</ion-label>
+        <ion-input [(ngModel)]="form.bookTitle" required></ion-input>
+      </ion-item>
+
+      <ion-item>
+        <ion-label position="stacked">Book Summary</ion-label>
+        <ion-textarea [(ngModel)]="form.bookSummary" required></ion-textarea>
+      </ion-item>
+
+      <ion-item>
         <ion-label>Need Help?</ion-label>
         <ion-checkbox slot="start" [(ngModel)]="form.needsHelp"></ion-checkbox>
       </ion-item>

--- a/src/app/project-tracker/project-tracker.page.ts
+++ b/src/app/project-tracker/project-tracker.page.ts
@@ -14,6 +14,7 @@ import {
   IonCheckbox,
   IonSelect,
   IonSelectOption,
+  IonTextarea,
   
 } from '@ionic/angular/standalone';
 import { FirebaseService } from '../services/firebase.service';
@@ -38,6 +39,7 @@ import { ToastController } from '@ionic/angular';
     IonCheckbox,
     IonSelect,
     IonSelectOption,
+    IonTextarea,
     CommonModule,
     ReactiveFormsModule
   ],
@@ -53,12 +55,20 @@ export class ProjectTrackerPage {
     needsHelp: false,
     enjoyment: 3,
     progress: 'in progress',
+    bookTitle: '',
+    bookSummary: '',
   };
 
   constructor(private fb: FirebaseService, private toastCtrl: ToastController) {}
 
   async submit() {
-    if (!this.form.title || !this.form.presentationDate || !this.form.enjoyment) {
+    if (
+      !this.form.title ||
+      !this.form.presentationDate ||
+      !this.form.enjoyment ||
+      !this.form.bookTitle ||
+      !this.form.bookSummary
+    ) {
       alert('Please fill in all required fields');
       return;
     }
@@ -82,6 +92,8 @@ export class ProjectTrackerPage {
       needsHelp: false,
       enjoyment: 3,
       progress: 'in progress',
+      bookTitle: '',
+      bookSummary: '',
     };
   }
 


### PR DESCRIPTION
## Summary
- capture assigned reading in project entries via bookTitle and bookSummary fields
- add UI and validation for book information on project tracker page

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab65ee13f48327929bc2af4e50f2d1