### PR TITLE
feat: add mentor board page

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -78,7 +78,7 @@
             <ion-icon slot="start" name="gift-outline"></ion-icon>
             <ion-label>Reward Center</ion-label>
           </ion-item>
-          <ion-item routerLink="/tabs/mentor-record" *ngIf="role === 'child' || role === 'parent' || role === 'mentor'">
+          <ion-item routerLink="/tabs/mentor-board" *ngIf="role === 'child' || role === 'parent' || role === 'mentor'">
             <ion-icon slot="start" name="chatbubble-ellipses-outline"></ion-icon>
             <ion-label>Mentor Board</ion-label>
           </ion-item>

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -47,12 +47,20 @@ export const routes: Routes = [
         data: { title: 'Project Tracker' },
       },
       {
+        path: 'mentor-board',
+        loadComponent: () =>
+          import('./mentor-board/mentor-board.page').then(
+            (m) => m.MentorBoardPage
+          ),
+        data: { title: 'Mentor Board' },
+      },
+      {
         path: 'mentor-record',
         loadComponent: () =>
           import('./mentor-record/mentor-record.page').then(
             (m) => m.MentorRecordPage
           ),
-        data: { title: 'Mentor Board' },
+        data: { title: 'Mentor Records' },
       },
       {
         path: 'admin',

--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -30,7 +30,7 @@
       </ion-row>
       <ion-row *ngIf="role === 'parent'">
         <ion-col size="6">
-          <ion-button class="tile-button" routerLink="/tabs/mentor-record" expand="block">Mentor Board</ion-button>
+          <ion-button class="tile-button" routerLink="/tabs/mentor-board" expand="block">Mentor Board</ion-button>
         </ion-col>
         <ion-col size="6">
           <ion-button class="tile-button" routerLink="/tabs/group" expand="block">Groups</ion-button>
@@ -40,7 +40,7 @@
       <!-- Mentor Buttons -->
       <ion-row *ngIf="role === 'mentor'">
         <ion-col size="6">
-          <ion-button class="tile-button" routerLink="/tabs/mentor-record" expand="block">Mentor Board</ion-button>
+          <ion-button class="tile-button" routerLink="/tabs/mentor-board" expand="block">Mentor Board</ion-button>
         </ion-col>
         <ion-col size="6">
           <ion-button class="tile-button" routerLink="/tabs/group" expand="block">Groups</ion-button>
@@ -132,7 +132,7 @@
         </ion-row>
         <ion-row>
           <ion-col size="6">
-          <ion-button class="tile-button" routerLink="/tabs/mentor-record" expand="block">
+          <ion-button class="tile-button" routerLink="/tabs/mentor-board" expand="block">
            <img src="assets/tiles/mentor-board.png" alt="Mentor Board" />
 
             <!-- <span>Mentor Board</span> -->

--- a/src/app/mentor-board/mentor-board.page.html
+++ b/src/app/mentor-board/mentor-board.page.html
@@ -1,0 +1,27 @@
+<div class="ion-page">
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Mentor Board</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content>
+    <ion-list>
+      <ion-item *ngFor="let mentor of mentors">
+        <ion-label>
+          <h2>{{ mentor.name }}</h2>
+          <p>Church: {{ mentor.church }}</p>
+          <p>Years in Christ: {{ mentor.yearsInChrist }}</p>
+          <p>Years served: {{ mentor.yearsServed }}</p>
+          <p>Education: {{ mentor.education }}</p>
+          <p>Kids mentored: {{ mentor.childCount }}</p>
+          <p>Improved last quarter: {{ mentor.improvementLastQuarter }}%</p>
+          <p>Improved last year: {{ mentor.improvementLastYear }}%</p>
+          <p>Certificate rate: {{ mentor.certificateRate }}%</p>
+        </ion-label>
+      </ion-item>
+      <ion-item *ngIf="mentors.length === 0">
+        <ion-label>No mentors found.</ion-label>
+      </ion-item>
+    </ion-list>
+  </ion-content>
+</div>

--- a/src/app/mentor-board/mentor-board.page.scss
+++ b/src/app/mentor-board/mentor-board.page.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/src/app/mentor-board/mentor-board.page.spec.ts
+++ b/src/app/mentor-board/mentor-board.page.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+import { MentorBoardPage } from './mentor-board.page';
+
+describe('MentorBoardPage', () => {
+  beforeEach(() => TestBed.configureTestingModule({ imports: [MentorBoardPage] }));
+
+  it('should create', () => {
+    const fixture = TestBed.createComponent(MentorBoardPage);
+    const app = fixture.componentInstance;
+    expect(app).toBeTruthy();
+  });
+});

--- a/src/app/mentor-board/mentor-board.page.ts
+++ b/src/app/mentor-board/mentor-board.page.ts
@@ -1,0 +1,48 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonContent,
+  IonList,
+  IonItem,
+  IonLabel,
+} from '@ionic/angular/standalone';
+import { MentorApiService } from '../services/mentor-api.service';
+import { MentorProfile } from '../models/mentor-profile';
+import { firstValueFrom } from 'rxjs';
+
+@Component({
+  selector: 'app-mentor-board',
+  standalone: true,
+  imports: [
+    CommonModule,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
+    IonContent,
+    IonList,
+    IonItem,
+    IonLabel,
+  ],
+  templateUrl: './mentor-board.page.html',
+  styleUrls: ['./mentor-board.page.scss'],
+})
+export class MentorBoardPage implements OnInit {
+  mentors: MentorProfile[] = [];
+
+  constructor(private mentorApi: MentorApiService) {}
+
+  async ngOnInit() {
+    await this.loadMentors();
+  }
+
+  async ionViewWillEnter() {
+    await this.loadMentors();
+  }
+
+  private async loadMentors() {
+    this.mentors = await firstValueFrom(this.mentorApi.getMentors());
+  }
+}

--- a/src/app/models/mentor-profile.ts
+++ b/src/app/models/mentor-profile.ts
@@ -3,4 +3,20 @@ export interface MentorProfile {
   name: string;
   email: string;
   phone: string;
+  /** Church the mentor is affiliated with */
+  church?: string;
+  /** Years since the mentor came to Christ */
+  yearsInChrist?: number;
+  /** Years the mentor has served at their current church */
+  yearsServed?: number;
+  /** Education background of the mentor */
+  education?: string;
+  /** Number of children currently mentored */
+  childCount?: number;
+  /** Percentage of mentees showing improvement last quarter */
+  improvementLastQuarter?: number;
+  /** Percentage of mentees showing improvement in the last year */
+  improvementLastYear?: number;
+  /** Average percentage of mentees winning certificates each quarter */
+  certificateRate?: number;
 }

--- a/src/app/tabs/tabs.page.html
+++ b/src/app/tabs/tabs.page.html
@@ -18,7 +18,7 @@
       <ion-icon name="home-outline"></ion-icon>
       <ion-label>Home</ion-label>
     </ion-tab-button>
-    <ion-tab-button tab="mentor-record" href="/tabs/mentor-record">
+    <ion-tab-button tab="mentor-board" href="/tabs/mentor-board">
       <ion-icon name="chatbubble-ellipses-outline"></ion-icon>
       <ion-label>Mentor</ion-label>
     </ion-tab-button>


### PR DESCRIPTION
## Summary
- add MentorBoardPage listing mentor profiles with church, experience, education, mentees, and improvement stats
- extend MentorProfile model with ministry and performance fields
- wire up new mentor board route and navigation links

## Testing
- `npm test -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab687687388327b3cd183e78667e29