### PR TITLE
feat: add quiz history tagline

### DIFF
--- a/src/app/quiz-history/quiz-history.page.html
+++ b/src/app/quiz-history/quiz-history.page.html
@@ -7,6 +7,10 @@
 <ion-content>
   <div class="ion-padding">
     <h2>Total Score: {{ totalScore }}</h2>
+    <p class="tagline">
+      Quiz History is the exhibition of points acquired with Bible reading
+      and associated quizzes, anchoring you in studying the Word of God.
+    </p>
   </div>
 
   <ion-list *ngIf="correctResults.length">

--- a/src/app/quiz-history/quiz-history.page.scss
+++ b/src/app/quiz-history/quiz-history.page.scss
@@ -1,0 +1,5 @@
+
+.tagline {
+  font-style: italic;
+}
+


### PR DESCRIPTION
## Summary
- add descriptive tagline to quiz history page
- style tagline for emphasis

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6d8158fc8327a7176b004c53c8d0