### PR TITLE
fix: adjust quiz endpoint path

### DIFF
--- a/src/app/services/bible-quiz-api.service.ts
+++ b/src/app/services/bible-quiz-api.service.ts
@@ -24,9 +24,7 @@ export class BibleQuizApiService {
     }
 
     return this.http
-      .get<BibleQuestion[]>(
-        `${environment.apiUrl}/quizzes/today?count=${count}`
-      )
+      .get<BibleQuestion[]>(`${environment.apiUrl}/quizzes?count=${count}`)
       .pipe(
         timeout(5000),
         catchError(() =>


### PR DESCRIPTION
## Summary
- request daily quiz questions from /quizzes to avoid missing endpoint

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abaee5d6f08327bf20c305b55fa108